### PR TITLE
Improve Algolia DocSearch styling for better accessibility

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -1518,3 +1518,21 @@ table tr:nth-child(2n) {
   max-height: 400px;
   overflow-y: auto;
 }
+
+.DocSearch-Hit[aria-selected=true] a {
+  background-color: #2a2a2a !important;
+}
+
+.DocSearch-Hit[aria-selected=true] .DocSearch-Hit-Tree,
+.DocSearch-Hit[aria-selected=true] .DocSearch-Hit-action,
+.DocSearch-Hit[aria-selected=true] .DocSearch-Hit-icon,
+.DocSearch-Hit[aria-selected=true] .DocSearch-Hit-path,
+.DocSearch-Hit[aria-selected=true] .DocSearch-Hit-text,
+.DocSearch-Hit[aria-selected=true] .DocSearch-Hit-title,
+.DocSearch-Hit[aria-selected=true] mark {
+  color: #ffffff !important;
+}
+
+.DocSearch-Hit[aria-selected=true] mark {
+  color: #ffdf00 !important;
+}


### PR DESCRIPTION
- Enhanced selected search result styling with dark background (#2a2a2a)
- Improved text contrast with white text on selected items
- Made search result highlights more visible with yellow color (#ffdf00)
- Better visual feedback for keyboard navigation in search

🤖 Generated with [Claude Code](https://claude.ai/code)