### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
     id("root.publication")
@@ -7,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.spotless) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotest.multiplatform) apply false
     alias(libs.plugins.dokka)
 }
@@ -29,6 +29,20 @@ subprojects {
     }
 }
 
-tasks.withType<DokkaMultiModuleTask> {
-    outputDirectory.set(projectDir.resolve("docs"))
+dokka {
+    dokkaPublications.html {
+        outputDirectory.set(projectDir.resolve("docs"))
+    }
+}
+
+dependencies {
+    dokka(project(":src:core"))
+    dokka(project(":src:tools:http"))
+    dokka(project(":src:tools:openapi"))
+    dokka(project(":src:platform"))
+    dokka(project(":src:providers:openai"))
+    dokka(project(":src:providers:gemini"))
+    dokka(project(":src:providers:vertexai"))
+    dokka(project(":src:providers:ollama"))
+    dokka(project(":src:cloud:google-cloud-function"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-kotlin = "2.1.10"
+kotlin = "2.3.10"
 coroutines = "1.10.2"
-serialization = "1.8.1"
-ktor = "3.2.2"
+serialization = "1.10.0"
+ktor = "3.4.0"
 nexus-publish = "2.0.0"
-kotlinOpenapiBindings = "0.0.24"
-kotest = "5.9.1"
-mockk = "1.14.5"
-openaiClient = "3.8.2"
+kotlinOpenapiBindings = "0.2.1"
+kotest = "6.1.3"
+mockk = "1.14.9"
+openaiClient = "4.1.0"
 google-cloud-functions-framework = "^3.5.1"
-wirespec = "0.9.23"
-logback = "1.5.6"
-google-gen-ai = "1.28.0"
+wirespec = "0.17.19"
+logback = "1.5.31"
+google-gen-ai = "1.39.0"
 
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -57,7 +57,7 @@ google-gen-ai = { module = "com.google.genai:google-genai", version.ref = "googl
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-spotless = { id = "com.diffplug.gradle.spotless", version = "6.20.0" }
-dokka = { id = "org.jetbrains.dokka", version = "1.8.20" }
+spotless = { id = "com.diffplug.gradle.spotless", version = "8.2.1" }
+dokka = { id = "org.jetbrains.dokka", version = "2.1.0" }
 kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest" }
 wirespec = { id = "community.flock.wirespec.plugin.gradle", version.ref = "wirespec" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "2.3.10"
+ksp = "2.3.5"
 coroutines = "1.10.2"
 serialization = "1.10.0"
 ktor = "3.4.0"
@@ -43,7 +44,6 @@ openai-client = { group = "com.aallam.openai", name = "openai-client", version.r
 #Test
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
-kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -57,7 +57,8 @@ google-gen-ai = { module = "com.google.genai:google-genai", version.ref = "googl
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-spotless = { id = "com.diffplug.gradle.spotless", version = "8.2.1" }
+spotless = { id = "com.diffplug.spotless", version = "8.2.1" }
 dokka = { id = "org.jetbrains.dokka", version = "2.1.0" }
-kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotest-multiplatform = { id = "io.kotest", version.ref = "kotest" }
 wirespec = { id = "community.flock.wirespec.plugin.gradle", version.ref = "wirespec" }

--- a/src/cloud/google-cloud-function/build.gradle.kts
+++ b/src/cloud/google-cloud-function/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest.multiplatform)
     alias(libs.plugins.kotlinx.serialization)
     id("module.publication")
@@ -23,7 +24,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotest.framework.datatest)
             }
         }
 

--- a/src/core/build.gradle.kts
+++ b/src/core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest.multiplatform)
     id("module.publication")
 }
@@ -30,7 +31,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotest.framework.datatest)
                 implementation(libs.kotest.property)
             }
         }

--- a/src/platform/build.gradle.kts
+++ b/src/platform/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest.multiplatform)
     alias(libs.plugins.wirespec)
     id("module.publication")
@@ -57,7 +58,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotest.framework.datatest)
                 implementation(libs.kotest.property)
                 implementation(libs.ktor.client.mock)
             }

--- a/src/providers/jsonschema/build.gradle.kts
+++ b/src/providers/jsonschema/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest.multiplatform)
     id("module.publication")
 }
@@ -24,7 +25,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotest.framework.datatest)
                 implementation(libs.kotest.property)
             }
         }

--- a/src/tools/http/build.gradle.kts
+++ b/src/tools/http/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("module.publication")
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest.multiplatform)
 }
 
@@ -34,7 +35,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotest.framework.datatest)
                 implementation(libs.kotest.property)
             }
         }

--- a/src/tools/openapi/build.gradle.kts
+++ b/src/tools/openapi/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest.multiplatform)
     id("module.publication")
 }
@@ -26,7 +27,6 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotest.framework.datatest)
             }
         }
 


### PR DESCRIPTION
- Kotlin 2.1.10 → 2.3.10
- kotlinx-serialization 1.8.1 → 1.10.0
- Ktor 3.2.2 → 3.4.0
- Kotest 5.9.1 → 6.1.3
- MockK 1.14.5 → 1.14.9
- OpenAI Client 3.8.2 → 4.1.0
- Wirespec 0.9.23 → 0.17.19
- Logback 1.5.6 → 1.5.31
- Google GenAI 1.28.0 → 1.39.0
- Spotless 6.20.0 → 8.2.1
- Dokka 1.8.20 → 2.1.0
- kotlin-openapi-bindings 0.0.24 → 0.2.1

https://claude.ai/code/session_01LVodyUMqLgmmf4MfJUy5cT