### PR TITLE
chore: upgrade wirespec from 0.9.23 to 0.17.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotest = "5.9.1"
 mockk = "1.14.9"
 openaiClient = "3.8.2"
 google-cloud-functions-framework = "^3.5.1"
-wirespec = "0.9.23"
+wirespec = "0.17.20"
 logback = "1.5.6"
 google-gen-ai = "1.28.0"
 
@@ -49,6 +49,7 @@ kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 #Wirespec
 wirespec-core = { group = "community.flock.wirespec.compiler", name = "core-jvm", version.ref = "wirespec" }
+wirespec-emitters-kotlin = { module = "community.flock.wirespec.compiler.emitters:kotlin-jvm", version.ref = "wirespec" }
 # Logging
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
 # Google GenAI

--- a/src/platform/build.gradle.kts
+++ b/src/platform/build.gradle.kts
@@ -1,11 +1,18 @@
-import community.flock.wirespec.compiler.core.emit.KotlinEmitter
-import community.flock.wirespec.compiler.core.emit.shared.KotlinShared
-import community.flock.wirespec.compiler.core.emit.transformer.ClassModelTransformer.transform
-import community.flock.wirespec.compiler.core.parse.AST
-import community.flock.wirespec.compiler.core.parse.Refined
-import community.flock.wirespec.compiler.core.parse.Type
-import community.flock.wirespec.compiler.core.parse.Union
-import community.flock.wirespec.plugin.gradle.CustomWirespecTask
+import community.flock.wirespec.compiler.core.emit.EmitShared
+import community.flock.wirespec.compiler.core.emit.PackageName
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import community.flock.wirespec.compiler.core.parse.ast.Union
+import community.flock.wirespec.emitters.kotlin.KotlinEmitter
+import community.flock.wirespec.plugin.gradle.CompileWirespecTask
+
+buildscript {
+    dependencies {
+        classpath(libs.wirespec.core)
+        classpath(libs.wirespec.emitters.kotlin)
+    }
+}
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -17,13 +24,12 @@ plugins {
 }
 
 
-val wirespecKotlin = tasks.register<CustomWirespecTask>("wirespec-kotlin") {
+val wirespecKotlin = tasks.register<CompileWirespecTask>("wirespec-kotlin") {
     input = layout.projectDirectory.dir("./wirespec")
     output = layout.buildDirectory.dir("generated")
     packageName = "community.flock.aigentic.gateway.wirespec"
-    emitter = KotlinSerializableEmitter::class.java
-    shared = KotlinShared.source
-    extension = "kt"
+    emitterClass = KotlinSerializableEmitter::class.java
+    shared = true
 }
 
 kotlin {
@@ -80,23 +86,23 @@ kotlin {
     }
 }
 
-class KotlinSerializableEmitter : KotlinEmitter("community.flock.aigentic.gateway.wirespec") {
+class KotlinSerializableEmitter(packageName: PackageName, emitShared: EmitShared) : KotlinEmitter(packageName, emitShared) {
 
-    override fun Type.emit(ast: AST) = """
+    override fun emit(type: Type, module: Module): String = """
     |@kotlinx.serialization.Serializable
-    |@kotlinx.serialization.SerialName("${identifier.value}")
-    |${transform(ast).emit()}
+    |@kotlinx.serialization.SerialName("${type.identifier.value}")
+    |${super.emit(type, module)}
     """.trimMargin()
 
-    override fun Refined.emit() = """
+    override fun emit(refined: Refined): String = """
     |@kotlinx.serialization.Serializable
-    |@kotlinx.serialization.SerialName("${identifier.value}")
-    |${transform().emit()}
+    |@kotlinx.serialization.SerialName("${refined.identifier.value}")
+    |${super.emit(refined)}
     """.trimMargin()
 
-    override fun Union.emit() = """
+    override fun emit(union: Union): String = """
     |@kotlinx.serialization.Serializable
-    |${transform().emit()}
+    |${super.emit(union)}
     """.trimMargin()
 
 }

--- a/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/client/PlatformClient.kt
+++ b/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/client/PlatformClient.kt
@@ -9,11 +9,11 @@ import community.flock.aigentic.core.platform.Authentication
 import community.flock.aigentic.core.platform.PlatformApiUrl
 import community.flock.aigentic.core.platform.PlatformClient
 import community.flock.aigentic.core.platform.RunSentResult
-import community.flock.aigentic.gateway.wirespec.GatewayEndpoint
-import community.flock.aigentic.gateway.wirespec.GetRunsEndpoint
+import community.flock.aigentic.gateway.wirespec.endpoint.Gateway
+import community.flock.aigentic.gateway.wirespec.endpoint.GetRuns
 import community.flock.aigentic.platform.mapper.toDto
 import community.flock.aigentic.platform.mapper.toRun
-import community.flock.wirespec.Wirespec
+import community.flock.wirespec.kotlin.Wirespec
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
@@ -27,17 +27,15 @@ import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.client.request.accept
 import io.ktor.client.request.basicAuth
 import io.ktor.client.request.header
-import io.ktor.client.request.parameter
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
+import io.ktor.http.appendPathSegments
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.util.toMap
 import io.ktor.utils.io.core.toByteArray
 import io.ktor.utils.io.toByteArray
 import kotlinx.serialization.KSerializer
@@ -45,7 +43,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import kotlin.reflect.KType
 
-interface PlatformEndpoints : GatewayEndpoint, GetRunsEndpoint
+interface PlatformEndpoints : Gateway.Handler, GetRuns.Handler
 
 const val defaultPlatformApiUrl = "https://aigentic-backend-kib53ypjwq-ez.a.run.app/"
 
@@ -60,24 +58,24 @@ class AigenticPlatformClient(
         outputSerializer: KSerializer<O>,
     ): RunSentResult {
         val runDto = run.toDto(agent, outputSerializer)
-        val request = GatewayEndpoint.RequestApplicationJson(runDto)
+        val request = Gateway.Request(body = runDto)
         return when (val response = endpoints.gateway(request)) {
-            is GatewayEndpoint.Response201Unit -> RunSentResult.Success
-            is GatewayEndpoint.Response401Unit -> RunSentResult.Unauthorized
-            is GatewayEndpoint.Response400ApplicationJson -> RunSentResult.Error(response.content.body.message)
-            is GatewayEndpoint.Response500ApplicationJson ->
+            is Gateway.Response201 -> RunSentResult.Success
+            is Gateway.Response401 -> RunSentResult.Unauthorized
+            is Gateway.Response400 -> RunSentResult.Error(response.body.message)
+            is Gateway.Response500 ->
                 RunSentResult.Error(
-                    "${response.content.body.name} - ${response.content.body.description}",
+                    "${response.body.name} - ${response.body.description}",
                 )
         }
     }
 
     override suspend fun getRuns(tags: List<RunTag>): List<Pair<RunId, AgentRun<String>>> =
-        when (val response = endpoints.getRuns(GetRunsEndpoint.RequestUnit(tags.joinToString(",") { it.value }))) {
-            is GetRunsEndpoint.Response200ApplicationJson -> response.content.body
-            is GetRunsEndpoint.Response401Unit -> aigenticException("Unauthorized to get runs")
-            is GetRunsEndpoint.Response404Unit -> aigenticException("Runs not found")
-            is GetRunsEndpoint.Response500ApplicationJson -> aigenticException("Internal server error")
+        when (val response = endpoints.getRuns(GetRuns.Request(tags = tags.joinToString(",") { it.value }))) {
+            is GetRuns.Response200 -> response.body
+            is GetRuns.Response401 -> aigenticException("Unauthorized to get runs")
+            is GetRuns.Response404 -> aigenticException("Runs not found")
+            is GetRuns.Response500 -> aigenticException("Internal server error")
         }.map { RunId(it.runId) to it.toRun() }
 }
 
@@ -113,87 +111,81 @@ class AigenticPlatformEndpoints(
 
     private val httpClient = if (engine != null) HttpClient(engine, configuration) else HttpClient(configuration)
 
-    override suspend fun gateway(request: GatewayEndpoint.Request<*>): GatewayEndpoint.Response<*> {
-        val responseMapper = GatewayEndpoint.RESPONSE_MAPPER(contentMapper)
-        return responseMapper(
-            when (request) {
-                is GatewayEndpoint.RequestApplicationJson ->
-                    httpClient.request(GatewayEndpoint.PATH) {
-                        method = GatewayEndpoint.METHOD.toMethod()
-                        contentType(request.content.type.toContentType())
-                        setBody(request.content.body)
-                    }
-            }.toWireSpecResponse(),
-        )
-    }
-
-    override suspend fun getRuns(request: GetRunsEndpoint.Request<*>): GetRunsEndpoint.Response<*> {
-        val responseMapper = GetRunsEndpoint.RESPONSE_MAPPER(contentMapper)
-        return responseMapper(
-            when (request) {
-                is GetRunsEndpoint.RequestUnit ->
-                    httpClient.request(GetRunsEndpoint.PATH) {
-                        method = GetRunsEndpoint.METHOD.toMethod()
-                        url {
-                            request.query.forEach { (key, values) ->
-                                values.forEach { value ->
-                                    // TODO does this work for multiple values or does it override?
-                                    parameter(key, value)
-                                }
-                            }
-                        }
-                    }
-            }.toWireSpecResponse(),
-        )
-    }
-
-    private suspend fun HttpResponse.toWireSpecResponse(): Wirespec.Response<ByteArray> {
-        val arr = bodyAsChannel().toByteArray()
-        val ktorResponse = this
-        return object : Wirespec.Response<ByteArray> {
-            override val status: Int = ktorResponse.status.value
-            override val headers: Map<String, List<Any?>> = ktorResponse.headers.toMap()
-            override val content: Wirespec.Content<ByteArray>? =
-                if (ktorResponse.contentType() != null && arr.isNotEmpty()) {
-                    Wirespec.Content(
-                        ktorResponse.contentType().toString(),
-                        arr,
-                    )
-                } else {
-                    null
-                }
-        }
-    }
-
-    private val contentMapper =
-        object : Wirespec.ContentMapper<ByteArray> {
+    private val serialization =
+        object : Wirespec.Serialization {
             val json =
                 Json {
                     prettyPrint = true
                     ignoreUnknownKeys = true
                 }
 
-            override fun <T> read(
-                content: Wirespec.Content<ByteArray>,
-                valueType: KType,
-            ): Wirespec.Content<T> {
-                return Wirespec.Content(
-                    content.type,
-                    json.decodeFromString(Json.serializersModule.serializer(valueType), content.body.decodeToString()) as T,
-                )
-            }
+            override fun <T : Any> serializeBody(
+                t: T,
+                kType: KType,
+            ): ByteArray = json.encodeToString(Json.serializersModule.serializer(kType), t).toByteArray()
 
-            override fun <T> write(
-                content: Wirespec.Content<T>,
-                valueType: KType,
-            ): Wirespec.Content<ByteArray> =
-                Wirespec.Content(
-                    content.type,
-                    json.encodeToString(Json.serializersModule.serializer(valueType), content.body).toByteArray(),
-                )
+            override fun <T : Any> deserializeBody(
+                raw: ByteArray,
+                kType: KType,
+            ): T = json.decodeFromString(Json.serializersModule.serializer(kType), raw.decodeToString()) as T
+
+            override fun <T : Any> serializePath(
+                t: T,
+                kType: KType,
+            ): String = t.toString()
+
+            override fun <T : Any> deserializePath(
+                raw: String,
+                kType: KType,
+            ): T = raw as T
+
+            override fun <T : Any> serializeParam(
+                value: T,
+                kType: KType,
+            ): List<String> = listOf(value.toString())
+
+            override fun <T : Any> deserializeParam(
+                values: List<String>,
+                kType: KType,
+            ): T = values.first() as T
         }
+
+    override suspend fun gateway(request: Gateway.Request): Gateway.Response<*> {
+        val edge = Gateway.Handler.client(serialization)
+        val rawRequest = edge.to(request)
+        val rawResponse = executeRequest(rawRequest)
+        return edge.from(rawResponse)
+    }
+
+    override suspend fun getRuns(request: GetRuns.Request): GetRuns.Response<*> {
+        val edge = GetRuns.Handler.client(serialization)
+        val rawRequest = edge.to(request)
+        val rawResponse = executeRequest(rawRequest)
+        return edge.from(rawResponse)
+    }
+
+    private suspend fun executeRequest(rawRequest: Wirespec.RawRequest): Wirespec.RawResponse {
+        val response =
+            httpClient.request {
+                method = HttpMethod.parse(rawRequest.method)
+                url {
+                    appendPathSegments(rawRequest.path)
+                    rawRequest.queries.forEach { (key, values) ->
+                        values.forEach { parameters.append(key, it) }
+                    }
+                }
+                rawRequest.headers.forEach { (name, values) ->
+                    values.forEach { header(name, it) }
+                }
+                rawRequest.body?.let {
+                    contentType(ContentType.Application.Json)
+                    setBody(it)
+                }
+            }
+        return Wirespec.RawResponse(
+            statusCode = response.status.value,
+            headers = response.headers.entries().associate { (key, values) -> key to values },
+            body = response.bodyAsChannel().toByteArray(),
+        )
+    }
 }
-
-private fun String.toContentType() = ContentType.parse(this)
-
-private fun String.toMethod() = HttpMethod.parse(this)

--- a/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/mapper/RequestMapper.kt
+++ b/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/mapper/RequestMapper.kt
@@ -13,38 +13,38 @@ import community.flock.aigentic.core.tool.Parameter
 import community.flock.aigentic.core.tool.ParameterType
 import community.flock.aigentic.core.tool.ParameterType.Primitive
 import community.flock.aigentic.core.tool.PrimitiveValue
-import community.flock.aigentic.gateway.wirespec.Base64MessageDto
-import community.flock.aigentic.gateway.wirespec.ConfigDto
-import community.flock.aigentic.gateway.wirespec.FatalResultDto
-import community.flock.aigentic.gateway.wirespec.FinishedResultDto
-import community.flock.aigentic.gateway.wirespec.MessageCategoryDto
-import community.flock.aigentic.gateway.wirespec.MessageDto
-import community.flock.aigentic.gateway.wirespec.MimeTypeDto
-import community.flock.aigentic.gateway.wirespec.ModelRequestInfoDto
-import community.flock.aigentic.gateway.wirespec.ParameterArrayDto
-import community.flock.aigentic.gateway.wirespec.ParameterDto
-import community.flock.aigentic.gateway.wirespec.ParameterEnumDto
-import community.flock.aigentic.gateway.wirespec.ParameterObjectDto
-import community.flock.aigentic.gateway.wirespec.ParameterPrimitiveDto
-import community.flock.aigentic.gateway.wirespec.ParameterTypeDto
-import community.flock.aigentic.gateway.wirespec.PrimitiveValueBooleanDto
-import community.flock.aigentic.gateway.wirespec.PrimitiveValueDto
-import community.flock.aigentic.gateway.wirespec.PrimitiveValueIntegerDto
-import community.flock.aigentic.gateway.wirespec.PrimitiveValueNumberDto
-import community.flock.aigentic.gateway.wirespec.PrimitiveValueStringDto
-import community.flock.aigentic.gateway.wirespec.PrimitiveValueTypeDto
-import community.flock.aigentic.gateway.wirespec.RunDto
-import community.flock.aigentic.gateway.wirespec.SenderDto
-import community.flock.aigentic.gateway.wirespec.StructuredOutputMessageDto
-import community.flock.aigentic.gateway.wirespec.StuckResultDto
-import community.flock.aigentic.gateway.wirespec.SystemPromptMessageDto
-import community.flock.aigentic.gateway.wirespec.TaskDto
-import community.flock.aigentic.gateway.wirespec.TextMessageDto
-import community.flock.aigentic.gateway.wirespec.ToolCallDto
-import community.flock.aigentic.gateway.wirespec.ToolCallsMessageDto
-import community.flock.aigentic.gateway.wirespec.ToolDto
-import community.flock.aigentic.gateway.wirespec.ToolResultMessageDto
-import community.flock.aigentic.gateway.wirespec.UrlMessageDto
+import community.flock.aigentic.gateway.wirespec.model.Base64MessageDto
+import community.flock.aigentic.gateway.wirespec.model.ConfigDto
+import community.flock.aigentic.gateway.wirespec.model.FatalResultDto
+import community.flock.aigentic.gateway.wirespec.model.FinishedResultDto
+import community.flock.aigentic.gateway.wirespec.model.MessageCategoryDto
+import community.flock.aigentic.gateway.wirespec.model.MessageDto
+import community.flock.aigentic.gateway.wirespec.model.MimeTypeDto
+import community.flock.aigentic.gateway.wirespec.model.ModelRequestInfoDto
+import community.flock.aigentic.gateway.wirespec.model.ParameterArrayDto
+import community.flock.aigentic.gateway.wirespec.model.ParameterDto
+import community.flock.aigentic.gateway.wirespec.model.ParameterEnumDto
+import community.flock.aigentic.gateway.wirespec.model.ParameterObjectDto
+import community.flock.aigentic.gateway.wirespec.model.ParameterPrimitiveDto
+import community.flock.aigentic.gateway.wirespec.model.ParameterTypeDto
+import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueBooleanDto
+import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueDto
+import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueIntegerDto
+import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueNumberDto
+import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueStringDto
+import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueTypeDto
+import community.flock.aigentic.gateway.wirespec.model.RunDto
+import community.flock.aigentic.gateway.wirespec.model.SenderDto
+import community.flock.aigentic.gateway.wirespec.model.StructuredOutputMessageDto
+import community.flock.aigentic.gateway.wirespec.model.StuckResultDto
+import community.flock.aigentic.gateway.wirespec.model.SystemPromptMessageDto
+import community.flock.aigentic.gateway.wirespec.model.TaskDto
+import community.flock.aigentic.gateway.wirespec.model.TextMessageDto
+import community.flock.aigentic.gateway.wirespec.model.ToolCallDto
+import community.flock.aigentic.gateway.wirespec.model.ToolCallsMessageDto
+import community.flock.aigentic.gateway.wirespec.model.ToolDto
+import community.flock.aigentic.gateway.wirespec.model.ToolResultMessageDto
+import community.flock.aigentic.gateway.wirespec.model.UrlMessageDto
 import community.flock.aigentic.providers.jsonschema.emitPropertiesAndRequired
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -131,6 +131,7 @@ private fun Parameter.toDto(): ParameterDto =
                 description = description,
                 isRequired = isRequired,
                 paramType = type.toDto(),
+                default = null,
                 values =
                     values.map { value ->
                         val parameterType = determineType(value)
@@ -264,6 +265,7 @@ private fun ToolCall.toDto(): ToolCallDto =
         id = id.id,
         name = name,
         arguments = arguments,
+        expectedArguments = null,
     )
 
 private fun MimeType.toDto(): MimeTypeDto =

--- a/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/mapper/ResponseMapper.kt
+++ b/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/mapper/ResponseMapper.kt
@@ -9,20 +9,20 @@ import community.flock.aigentic.core.message.Sender
 import community.flock.aigentic.core.message.ToolCall
 import community.flock.aigentic.core.message.ToolCallId
 import community.flock.aigentic.core.message.ToolResultContent
-import community.flock.aigentic.gateway.wirespec.Base64MessageDto
-import community.flock.aigentic.gateway.wirespec.FatalResultDto
-import community.flock.aigentic.gateway.wirespec.FinishedResultDto
-import community.flock.aigentic.gateway.wirespec.MessageCategoryDto
-import community.flock.aigentic.gateway.wirespec.MimeTypeDto
-import community.flock.aigentic.gateway.wirespec.RunDetailsDto
-import community.flock.aigentic.gateway.wirespec.SenderDto
-import community.flock.aigentic.gateway.wirespec.StructuredOutputMessageDto
-import community.flock.aigentic.gateway.wirespec.StuckResultDto
-import community.flock.aigentic.gateway.wirespec.SystemPromptMessageDto
-import community.flock.aigentic.gateway.wirespec.TextMessageDto
-import community.flock.aigentic.gateway.wirespec.ToolCallsMessageDto
-import community.flock.aigentic.gateway.wirespec.ToolResultMessageDto
-import community.flock.aigentic.gateway.wirespec.UrlMessageDto
+import community.flock.aigentic.gateway.wirespec.model.Base64MessageDto
+import community.flock.aigentic.gateway.wirespec.model.FatalResultDto
+import community.flock.aigentic.gateway.wirespec.model.FinishedResultDto
+import community.flock.aigentic.gateway.wirespec.model.MessageCategoryDto
+import community.flock.aigentic.gateway.wirespec.model.MimeTypeDto
+import community.flock.aigentic.gateway.wirespec.model.RunDetailsDto
+import community.flock.aigentic.gateway.wirespec.model.SenderDto
+import community.flock.aigentic.gateway.wirespec.model.StructuredOutputMessageDto
+import community.flock.aigentic.gateway.wirespec.model.StuckResultDto
+import community.flock.aigentic.gateway.wirespec.model.SystemPromptMessageDto
+import community.flock.aigentic.gateway.wirespec.model.TextMessageDto
+import community.flock.aigentic.gateway.wirespec.model.ToolCallsMessageDto
+import community.flock.aigentic.gateway.wirespec.model.ToolResultMessageDto
+import community.flock.aigentic.gateway.wirespec.model.UrlMessageDto
 import kotlin.time.Instant
 
 internal fun RunDetailsDto.toRun(): AgentRun<String> {

--- a/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformClientTest.kt
+++ b/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformClientTest.kt
@@ -3,9 +3,9 @@ package community.flock.aigentic.platform.client
 import community.flock.aigentic.core.platform.Authentication
 import community.flock.aigentic.core.platform.PlatformApiUrl
 import community.flock.aigentic.core.platform.RunSentResult
-import community.flock.aigentic.gateway.wirespec.GatewayClientErrorDto
-import community.flock.aigentic.gateway.wirespec.GatewayEndpoint
-import community.flock.aigentic.gateway.wirespec.ServerErrorDto
+import community.flock.aigentic.gateway.wirespec.endpoint.Gateway
+import community.flock.aigentic.gateway.wirespec.model.GatewayClientErrorDto
+import community.flock.aigentic.gateway.wirespec.model.ServerErrorDto
 import community.flock.aigentic.platform.util.createAgent
 import community.flock.aigentic.platform.util.createAgentRun
 import io.kotest.core.spec.style.DescribeSpec
@@ -19,14 +19,14 @@ class AigenticPlatformClientTest : DescribeSpec({
 
     withData(
         nameFn = { "Should map ${it.wirespecResponse} to ${it.runSentResult}" },
-        TestCase(GatewayEndpoint.Response201Unit(), RunSentResult.Success),
-        TestCase(GatewayEndpoint.Response401Unit(), RunSentResult.Unauthorized),
+        TestCase(Gateway.Response201(body = Unit), RunSentResult.Success),
+        TestCase(Gateway.Response401(body = Unit), RunSentResult.Unauthorized),
         TestCase(
-            GatewayEndpoint.Response400ApplicationJson(GatewayClientErrorDto("invalid request")),
+            Gateway.Response400(body = GatewayClientErrorDto("invalid request")),
             RunSentResult.Error("invalid request"),
         ),
         TestCase(
-            GatewayEndpoint.Response500ApplicationJson(ServerErrorDto("error", "something went wrong")),
+            Gateway.Response500(body = ServerErrorDto("error", "something went wrong")),
             RunSentResult.Error("error - something went wrong"),
         ),
     ) {
@@ -55,4 +55,4 @@ class AigenticPlatformClientTest : DescribeSpec({
     }
 })
 
-private data class TestCase<T>(val wirespecResponse: GatewayEndpoint.Response<T>, val runSentResult: RunSentResult)
+private data class TestCase<T : Any>(val wirespecResponse: Gateway.Response<T>, val runSentResult: RunSentResult)

--- a/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformEndpointsTest.kt
+++ b/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformEndpointsTest.kt
@@ -2,7 +2,7 @@ package community.flock.aigentic.platform.client
 
 import community.flock.aigentic.core.platform.Authentication
 import community.flock.aigentic.core.platform.PlatformApiUrl
-import community.flock.aigentic.gateway.wirespec.GatewayEndpoint
+import community.flock.aigentic.gateway.wirespec.endpoint.Gateway
 import community.flock.aigentic.platform.mapper.toDto
 import community.flock.aigentic.platform.util.createAgent
 import community.flock.aigentic.platform.util.createAgentRun
@@ -25,7 +25,7 @@ class AigenticPlatformEndpointsTest : DescribeSpec({
         val mockEngine =
             MockEngine { request ->
                 when (request.method to request.url.encodedPath) {
-                    (HttpMethod.Post to "/gateway") ->
+                    (HttpMethod.Post to "/gateway/runs") ->
                         respond(content = ByteReadChannel.Empty, status = HttpStatusCode.Created)
                     else ->
                         error("Unexpected endpoint called! ${request.url.encodedPath}")
@@ -34,7 +34,7 @@ class AigenticPlatformEndpointsTest : DescribeSpec({
 
         val apiClient = AigenticPlatformEndpoints(Authentication.BasicAuth("", ""), PlatformApiUrl(""), mockEngine)
 
-        val req = GatewayEndpoint.RequestApplicationJson(run.toDto(agent, serializer<String>()))
+        val req = Gateway.Request(body = run.toDto(agent, serializer<String>()))
         val res = apiClient.gateway(req)
 
         res.status shouldBe HttpStatusCode.Created.value


### PR DESCRIPTION
## Summary

- Upgrade wirespec from 0.9.23 to 0.17.20, adapting to the new plugin and emitter API
- Generated code now uses sub-packages (`model` for DTOs, `endpoint` for endpoints)
- Platform client rewritten to use the new `Wirespec.Serialization`/`RawRequest`/`RawResponse` pattern instead of the old `ContentMapper`/`Content` pattern

## Breaking changes handled

- `CustomWirespecTask` → `CompileWirespecTask`
- `KotlinEmitter` moved to `community.flock.wirespec.emitters.kotlin` (separate artifact `wirespec-emitters-kotlin`)
- Emitter API changed from extension functions to regular functions with `super.emit()` delegation
- Constructor now takes `(PackageName, EmitShared)` for proper reflection-based instantiation
- Endpoint classes renamed: `GatewayEndpoint` → `Gateway`, `GetRunsEndpoint` → `GetRuns`
- Response classes simplified: `Response201Unit` → `Response201`, `Response400ApplicationJson` → `Response400`
- Request classes simplified: `RequestApplicationJson(dto)` → `Request(body = dto)`

## Serialization compatibility

Verified against [aigentic-platform](https://github.com/flock-community/aigentic-platform):
- `@Serializable` and `@SerialName("TypeName")` annotations are correctly generated on all types and union members
- Uses default `classDiscriminator = "type"` — matches the platform's deserialization config
- Wire format is identical to the previous version

## Test plan

- [x] Wirespec code generation succeeds (`wirespec-kotlin` task)
- [x] Platform module compiles for both JVM and JS targets
- [x] All platform tests pass (`jvmTest`)
- [x] Spotless formatting applied