### PR TITLE
test: add platform publish integration test runner

### DIFF
--- a/src/examples/testing/build.gradle.kts
+++ b/src/examples/testing/build.gradle.kts
@@ -30,3 +30,12 @@ kotlin {
         }
     }
 }
+
+tasks.register<JavaExec>("runPlatformPublishIntegrationTest") {
+    group = "verification"
+    description = "Runs the platform publish integration test (requires env vars)."
+    mainClass.set("community.flock.aigentic.test.PlatformPublishIntegrationTestKt")
+    classpath = kotlin.jvm().compilations["main"].output.allOutputs +
+        kotlin.jvm().compilations["main"].runtimeDependencyFiles!!
+    standardInput = System.`in`
+}

--- a/src/examples/testing/src/jvmMain/kotlin/community/flock/aigentic/test/PlatformPublishIntegrationTest.kt
+++ b/src/examples/testing/src/jvmMain/kotlin/community/flock/aigentic/test/PlatformPublishIntegrationTest.kt
@@ -1,0 +1,54 @@
+package community.flock.aigentic.test
+
+import community.flock.aigentic.core.agent.start
+import community.flock.aigentic.core.agent.tokenUsage
+import community.flock.aigentic.core.agent.tool.Outcome
+import community.flock.aigentic.core.annotations.AigenticParameter
+import community.flock.aigentic.core.dsl.agent
+import community.flock.aigentic.gemini.dsl.geminiModel
+import community.flock.aigentic.gemini.model.GeminiModelIdentifier
+import community.flock.aigentic.platform.dsl.platform
+import kotlinx.coroutines.runBlocking
+
+@AigenticParameter
+data class QAAnswer(
+    val answer: String,
+)
+
+fun main(): Unit =
+    runBlocking {
+        val geminiKey =
+            System.getenv("GEMINI_API_KEY")
+                ?: error("Set 'GEMINI_API_KEY' environment variable!")
+        val platformName =
+            System.getenv("AIGENTIC_PLATFORM_NAME")
+                ?: error("Set 'AIGENTIC_PLATFORM_NAME' environment variable!")
+        val platformSecret =
+            System.getenv("AIGENTIC_PLATFORM_SECRET")
+                ?: error("Set 'AIGENTIC_PLATFORM_SECRET' environment variable!")
+
+        val qaAgent =
+            agent<String, QAAnswer> {
+                geminiModel {
+                    apiKey(geminiKey)
+                    modelIdentifier(GeminiModelIdentifier.Gemini2_0Flash)
+                }
+                task("Answer general knowledge questions") {
+                    addInstruction("Provide a concise one-sentence answer")
+                }
+                platform {
+                    name(platformName)
+                    secret(platformSecret)
+                }
+            }
+
+        val run = qaAgent.start("What is the capital of France?")
+
+        when (val outcome = run.outcome) {
+            is Outcome.Finished -> println("AGENT_OUTCOME=Finished answer=${outcome.response?.answer}")
+            is Outcome.Stuck -> println("AGENT_OUTCOME=Stuck reason=${outcome.reason}")
+            is Outcome.Fatal -> println("AGENT_OUTCOME=Fatal message=${outcome.message}")
+        }
+
+        println("TOKEN_USAGE=${run.tokenUsage()}")
+    }


### PR DESCRIPTION
## Summary
- Adds a minimal Gemini-based Q&A agent main that exercises the `platform { ... }` DSL end-to-end (`PlatformPublishIntegrationTest.kt`).
- Adds a `runPlatformPublishIntegrationTest` Gradle `JavaExec` task on `:src:examples:testing` that runs the main with `GEMINI_API_KEY`, `AIGENTIC_PLATFORM_NAME`, and `AIGENTIC_PLATFORM_SECRET` from the environment (no hardcoded secrets).

## Context
Used to verify whether an agent run can be published to the Aigentic platform.

In a live run the agent executed correctly (Gemini answered "Paris") and the publish call reached the platform, but the platform responded with **HTTP 403** for the supplied agent name `integration-test`. That's surfaced as `Could not publish run to Aigentic platform: Cannot match response with status: 403` because the Wirespec contract for the publish endpoint only models 200/401 — any other status falls through. So the wiring is correct; the 403 needs to be resolved on the platform side (verify the agent exists and the secret matches).

## Test plan
- [ ] Set `GEMINI_API_KEY`, `AIGENTIC_PLATFORM_NAME`, `AIGENTIC_PLATFORM_SECRET`
- [ ] Run `./gradlew :src:examples:testing:runPlatformPublishIntegrationTest`
- [ ] Confirm stdout contains `Published run to Aigentic platform!`

https://claude.ai/code/session_01QsAUfPQwZBjK54RyguwxVr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsAUfPQwZBjK54RyguwxVr)_