### PR TITLE
feat!: update model identifiers to current OpenAI and Gemini models

### DIFF
--- a/site/docs/dsl/agent.mdx
+++ b/site/docs/dsl/agent.mdx
@@ -16,7 +16,7 @@ The main entry point for creating an agent is the `agent` function, which takes 
 val myAgent = agent {
     geminiModel {
         apiKey("your-api-key")
-        modelIdentifier(GeminiModelIdentifier.Gemini2_0Flash)
+        modelIdentifier(GeminiModelIdentifier.Gemini2_5Flash)
     }
     task("Answer questions about the weather") {
         addInstruction("Provide accurate and concise weather information")

--- a/site/docs/getting-started/getting-started.mdx
+++ b/site/docs/getting-started/getting-started.mdx
@@ -266,7 +266,7 @@ suspend fun main() {
         // Configure the Gemini model for the agent
         geminiModel {
             apiKey("YOUR_API_KEY")
-            modelIdentifier(GeminiModelIdentifier.Gemini2_0Flash)
+            modelIdentifier(GeminiModelIdentifier.Gemini2_5Flash)
         }
 
         // Configure the task for the agent

--- a/src/examples/simple-tools/src/commonMain/kotlin/community/flock/aigentic/example/AdministrativeAgentExample.kt
+++ b/src/examples/simple-tools/src/commonMain/kotlin/community/flock/aigentic/example/AdministrativeAgentExample.kt
@@ -16,7 +16,7 @@ suspend fun runAdministrativeAgentExample(apiKey: String) {
             geminiModel {
                 logLevel(LogLevel.DEBUG)
                 apiKey(apiKey)
-                modelIdentifier(GeminiModelIdentifier.Gemini2_0Flash)
+                modelIdentifier(GeminiModelIdentifier.Gemini2_5Flash)
             }
             task("Retrieve all employees to inspect their hour status") {
                 addInstruction(

--- a/src/examples/simple-tools/src/commonMain/kotlin/community/flock/aigentic/example/KotlinMessageSenderExample.kt
+++ b/src/examples/simple-tools/src/commonMain/kotlin/community/flock/aigentic/example/KotlinMessageSenderExample.kt
@@ -22,7 +22,7 @@ suspend fun runKotlinMessageAgent(apiKey: String) {
         agent {
             geminiModel {
                 apiKey(apiKey)
-                modelIdentifier(GeminiModelIdentifier.Gemini2_0Flash)
+                modelIdentifier(GeminiModelIdentifier.Gemini2_5Flash)
             }
             task("Send 2 nice messages about Kotlin") {
                 addInstruction("use the sendMessageTool to send an individual message")

--- a/src/examples/simple-tools/src/jvmMain/kotlin/community/flock/aigentic/example/VertexAIWeatherExampleMain.kt
+++ b/src/examples/simple-tools/src/jvmMain/kotlin/community/flock/aigentic/example/VertexAIWeatherExampleMain.kt
@@ -39,7 +39,7 @@ suspend fun runVertexAIWeatherExample(
             vertexAIModel {
                 project(project)
                 location(location)
-                modelIdentifier(VertexAIModelIdentifier.Gemini2_0Flash)
+                modelIdentifier(VertexAIModelIdentifier.Gemini2_5Flash)
             }
             task("Provide weather information to users") {
                 addInstruction("You are a helpful weather assistant that provides weather information for different locations.")

--- a/src/examples/testing/src/jvmMain/kotlin/community/flock/aigentic/test/TestingExample.kt
+++ b/src/examples/testing/src/jvmMain/kotlin/community/flock/aigentic/test/TestingExample.kt
@@ -45,7 +45,7 @@ val licencePlateExtractor =
         addTool(invoiceExtractTool)
         geminiModel {
             apiKey(geminiKey)
-            modelIdentifier(GeminiModelIdentifier.Gemini2_0Flash)
+            modelIdentifier(GeminiModelIdentifier.Gemini2_5Flash)
         }
         platform {
             name("licence-plate-extractor")

--- a/src/providers/gemini/src/commonMain/kotlin/community/flock/aigentic/gemini/model/GeminiModel.kt
+++ b/src/providers/gemini/src/commonMain/kotlin/community/flock/aigentic/gemini/model/GeminiModel.kt
@@ -19,13 +19,19 @@ import community.flock.aigentic.gemini.mapper.toModelResponse
 sealed class GeminiModelIdentifier(
     override val stringValue: String,
 ) : ModelIdentifier {
-    data object Gemini2_5Flash : GeminiModelIdentifier("gemini-2.5-flash")
+    data object Gemini3_5Flash : GeminiModelIdentifier("gemini-3.5-flash")
+
+    data object Gemini3_1ProPreview : GeminiModelIdentifier("gemini-3.1-pro-preview")
+
+    data object Gemini3_1FlashLite : GeminiModelIdentifier("gemini-3.1-flash-lite")
+
+    data object Gemini3FlashPreview : GeminiModelIdentifier("gemini-3-flash-preview")
 
     data object Gemini2_5Pro : GeminiModelIdentifier("gemini-2.5-pro")
 
-    data object Gemini2_0Flash : GeminiModelIdentifier("gemini-2.0-flash")
+    data object Gemini2_5Flash : GeminiModelIdentifier("gemini-2.5-flash")
 
-    data object Gemini2_0FlashLite : GeminiModelIdentifier("gemini-2.0-flash-lite")
+    data object Gemini2_5FlashLite : GeminiModelIdentifier("gemini-2.5-flash-lite")
 
     data class Custom(
         val identifier: String,

--- a/src/providers/openai/src/commonMain/kotlin/community/flock/aigentic/openai/model/OpenAIModel.kt
+++ b/src/providers/openai/src/commonMain/kotlin/community/flock/aigentic/openai/model/OpenAIModel.kt
@@ -25,6 +25,30 @@ import com.aallam.openai.api.logging.LogLevel as OpenAILogLevel
 sealed class OpenAIModelIdentifier(
     override val stringValue: String,
 ) : ModelIdentifier {
+    data object GPT5_5 : OpenAIModelIdentifier("gpt-5.5")
+
+    data object GPT5_5Pro : OpenAIModelIdentifier("gpt-5.5-pro")
+
+    data object GPT5_4 : OpenAIModelIdentifier("gpt-5.4")
+
+    data object GPT5_4Pro : OpenAIModelIdentifier("gpt-5.4-pro")
+
+    data object GPT5_4Mini : OpenAIModelIdentifier("gpt-5.4-mini")
+
+    data object GPT5_4Nano : OpenAIModelIdentifier("gpt-5.4-nano")
+
+    data object GPT5 : OpenAIModelIdentifier("gpt-5")
+
+    data object GPT5Mini : OpenAIModelIdentifier("gpt-5-mini")
+
+    data object GPT5Nano : OpenAIModelIdentifier("gpt-5-nano")
+
+    data object GPT4_1 : OpenAIModelIdentifier("gpt-4.1")
+
+    data object GPT4_1Mini : OpenAIModelIdentifier("gpt-4.1-mini")
+
+    data object GPT4_1Nano : OpenAIModelIdentifier("gpt-4.1-nano")
+
     data object GPT4O : OpenAIModelIdentifier("gpt-4o")
 
     data object GPT4OMini : OpenAIModelIdentifier("gpt-4o-mini")
@@ -33,17 +57,7 @@ sealed class OpenAIModelIdentifier(
 
     data object GPT3_5Turbo : OpenAIModelIdentifier("gpt-3.5-turbo")
 
-    data object GPT4_1 : OpenAIModelIdentifier("gpt-4.1")
-
-    data object GPT4_1Mini : OpenAIModelIdentifier("gpt-4.1-mini")
-
-    data object GPT4_1Nano : OpenAIModelIdentifier("gpt-4.1-nano")
-
-    data object GPT4_5Preview : OpenAIModelIdentifier("gpt-4.5-preview")
-
-    data object O1 : OpenAIModelIdentifier("o1")
-
-    data object O1Pro : OpenAIModelIdentifier("o1-pro")
+    data object O3Pro : OpenAIModelIdentifier("o3-pro")
 
     data object O3 : OpenAIModelIdentifier("o3")
 
@@ -51,7 +65,9 @@ sealed class OpenAIModelIdentifier(
 
     data object O3Mini : OpenAIModelIdentifier("o3-mini")
 
-    data object O1Mini : OpenAIModelIdentifier("o1-mini")
+    data object O1 : OpenAIModelIdentifier("o1")
+
+    data object O1Pro : OpenAIModelIdentifier("o1-pro")
 
     data object GPT4OMiniSearchPreview : OpenAIModelIdentifier("gpt-4o-mini-search-preview")
 

--- a/src/providers/vertexai/src/jvmMain/kotlin/community/flock/aigentic/vertexai/VertexAIModel.kt
+++ b/src/providers/vertexai/src/jvmMain/kotlin/community/flock/aigentic/vertexai/VertexAIModel.kt
@@ -18,13 +18,19 @@ import kotlinx.coroutines.future.await
 sealed class VertexAIModelIdentifier(
     override val stringValue: String,
 ) : ModelIdentifier {
-    data object Gemini2_5Flash : VertexAIModelIdentifier("gemini-2.5-flash")
+    data object Gemini3_5Flash : VertexAIModelIdentifier("gemini-3.5-flash")
+
+    data object Gemini3_1ProPreview : VertexAIModelIdentifier("gemini-3.1-pro-preview")
+
+    data object Gemini3_1FlashLite : VertexAIModelIdentifier("gemini-3.1-flash-lite")
+
+    data object Gemini3FlashPreview : VertexAIModelIdentifier("gemini-3-flash-preview")
 
     data object Gemini2_5Pro : VertexAIModelIdentifier("gemini-2.5-pro")
 
-    data object Gemini2_0Flash : VertexAIModelIdentifier("gemini-2.0-flash")
+    data object Gemini2_5Flash : VertexAIModelIdentifier("gemini-2.5-flash")
 
-    data object Gemini2_0FlashLite : VertexAIModelIdentifier("gemini-2.0-flash-lite")
+    data object Gemini2_5FlashLite : VertexAIModelIdentifier("gemini-2.5-flash-lite")
 
     data class Custom(
         val identifier: String,


### PR DESCRIPTION
## Summary

Brings the provider `ModelIdentifier` lists up to date with the current model lineups, verified against OpenAI's and Google's official model/deprecation docs (June 2026). Adds the latest flagship families, removes identifiers for models the providers have **shut down**, and reorders each list flagship-first.

## OpenAI (`OpenAIModelIdentifier`)

**Added:** `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `o3-pro`

**Removed (shut down by OpenAI):** `gpt-4.5-preview` (sunset Jul 2025), `o1-mini` (sunset Oct 2025)

Deprecated-but-still-functional models (`gpt-4-turbo`, `gpt-3.5-turbo`, `o1`, `o1-pro`, `o3-mini`, `o4-mini`, the `*-search-preview` pair) are kept.

## Gemini & VertexAI (`GeminiModelIdentifier` / `VertexAIModelIdentifier`)

**Added:** `gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-2.5-flash-lite`, plus previews `gemini-3.1-pro-preview` and `gemini-3-flash-preview` (no stable GA Gemini 3 Pro exists yet)

**Removed (shut down by Google):** `gemini-2.0-flash`, `gemini-2.0-flash-lite`

## Examples & docs

The 4 examples and 2 docs pages that referenced the now-removed `Gemini2_0Flash` were updated to `Gemini2_5Flash`.

## Breaking change

This removes the public identifiers `OpenAIModelIdentifier.GPT4_5Preview`, `OpenAIModelIdentifier.O1Mini`, and the `Gemini2_0Flash` / `Gemini2_0FlashLite` entries from `GeminiModelIdentifier` and `VertexAIModelIdentifier`. These all pointed at models that no longer respond. Any of them can still be reached via the `Custom(identifier)` escape hatch if needed.

## Verification

- `./gradlew spotlessApply` — clean
- `./gradlew --no-build-cache :src:providers:openai:jvmTest :src:providers:gemini:jvmTest :src:providers:vertexai:jvmTest :src:examples:simple-tools:compileKotlinJvm :src:examples:testing:compileKotlinJvm` — **BUILD SUCCESSFUL**, all tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPCqpoCEbkRHZvRCc1VuK8)_