### PR TITLE
feat: Koog → Aigentic Platform run-publishing proof-of-concept

### DIFF
--- a/poc/koog-platform/README.md
+++ b/poc/koog-platform/README.md
@@ -80,13 +80,65 @@ Two caveats:
    mapper (`toMimeTypeDto()` returns `null`). Supporting more would require extending `MimeTypeDto` in
    `gateway.ws`. Koog's `Reasoning` parts (thinking) likewise have no Aigentic message type and are dropped.
 
-2. **Structured output.** Aigentic has a dedicated `StructuredOutputMessageDto`, but Koog has no
-   distinct structured-output message — it is a normal `Message.Assistant` whose text is JSON (produced
-   via `LLMParams.schema`). It maps to `TextMessageDto` by default; emitting `StructuredOutputMessageDto`
-   would be a policy choice (e.g. "when a response schema is configured, treat the final assistant
-   message as structured output").
+2. **Structured output.** Aigentic has a dedicated `StructuredOutputMessageDto`. Koog has no distinct
+   structured-output *message* type, but it fully supports structured output as a first-class agent
+   feature (see below). The structured result is captured as the run's result; at the message level it
+   is the final `Message.Assistant` text (JSON).
 
 `KoogRunMapperTest` covers the supported types end-to-end and asserts the unsupported-MIME skip.
+
+## Structured output (typed request/response, e.g. "PDF invoice → line items → done")
+
+Yes — this is fully supported in Koog and is arguably *more* first-class than in Aigentic. Koog gives
+a typed `AIAgent<Input, Output>` whose `run(...)` returns the parsed object directly:
+
+```kotlin
+@Serializable
+@LLMDescription("An invoice with its line items")
+data class Invoice(
+    @property:LLMDescription("Invoice number") val number: String,
+    @property:LLMDescription("Total amount due") val total: Double,
+    val items: List<LineItem>,
+) { @Serializable data class LineItem(val description: String, val amount: Double) }
+
+val extractInvoice = strategy<String, Invoice>("invoice-extraction") {
+    val extract by nodeLLMRequestStructured<Invoice>()   // schema is derived from the @Serializable type
+    edge(nodeStart forwardTo extract)
+    edge(extract forwardTo nodeFinish transformed { it.getOrThrow().data })
+}
+
+val agent = AIAgent(promptExecutor = executor, llmModel = model, strategy = extractInvoice) {
+    aigenticPlatform(name = "…", secret = "…")
+}
+val invoice: Invoice = agent.run("…")   // typed result, then the run is published
+```
+
+How it works under the hood (`PromptExecutor.executeStructured` / `requestLLMStructured<T>`): Koog
+derives a JSON schema from the `@Serializable` type, uses the model's native structured-output mode when
+available (`LLMCapability.Schema.JSON.Standard/Basic`) or otherwise a manual mode (schema in the prompt),
+then parses the assistant's JSON back into `T` (with an optional `StructureFixingParser` to repair
+malformed output). This is the direct equivalent of Aigentic's `Outcome.Finished` carrying a typed `O`.
+
+**Feeding a PDF in:** attach the document to the user message and request the structure in one node:
+
+```kotlin
+val extract by node<String, Result<StructuredResponse<Invoice>>> {
+    llm.writeSession {
+        appendPrompt {
+            user("Extract the invoice") {
+                attachments {
+                    binaryFile(pdfBytes, format = "pdf", mimeType = "application/pdf")
+                }
+            }
+        }
+        requestLLMStructured<Invoice>()
+    }
+}
+```
+
+**Mapping to the platform:** the structured result becomes `FinishedResultDto.response` (the JSON output),
+and the same JSON also appears in `messages` as the assistant message. `StructuredOutputExporterTest`
+runs exactly this flow (with a mocked LLM) and asserts the published `RunDto` carries the typed invoice.
 
 ## Why this is an isolated build (important finding)
 

--- a/poc/koog-platform/README.md
+++ b/poc/koog-platform/README.md
@@ -1,0 +1,69 @@
+# PoC: publishing Koog runs to the Aigentic Platform
+
+This proof-of-concept answers the question: **can [JetBrains Koog](https://github.com/JetBrains/koog)
+publish its agent runs to the Aigentic Platform, using the same contract Aigentic itself uses?**
+
+**Answer: yes.** No fork or patch of Koog is required — Koog exposes public extension points
+that surface everything the platform contract needs.
+
+## How Aigentic publishes a run (the contract we target)
+
+After every run, Aigentic calls `publishRun` (`src/core/.../agent/AgentExecutor.kt`) which,
+when a `platform { … }` is configured, does a single authenticated request:
+
+```
+POST RunDto  ->  /gateway/runs        (HTTP Basic Auth; 201 / 401 / 400 / 500)
+```
+
+`RunDto` is defined in `src/platform/wirespec/gateway.ws` and carries `startedAt`, `finishedAt`,
+`config` (task, model identifier, system prompt, tools, temperature, …), `result`
+(Finished / Stuck / Fatal), `messages[]`, and `modelRequests[]` (per-LLM-call token usage).
+
+Nothing about publishing is runtime-specific: it is just "build a `RunDto` and POST it".
+
+## How this PoC does the same from Koog
+
+Koog's `agents-features-event-handler` feature lets you hook the full agent lifecycle. We install
+it via a small extension, `aigenticPlatform(name, secret, …)`, which uses `handleEvents { … }` to
+collect the run and POST a `RunDto` on completion — mirroring Aigentic's `publishRun`:
+
+```kotlin
+val agent = AIAgent(promptExecutor = executor, llmModel = model, systemPrompt = "…") {
+    aigenticPlatform(name = "…", secret = "…")   // <- publishes the run on completion
+}
+agent.run("…")   // on completion a RunDto is POSTed to /gateway/runs
+```
+
+Hooks used (`AigenticPlatformExporter.kt`):
+- `onAgentStarting` — run start time.
+- `onLLMCallStarting` / `onLLMCallCompleted` — full `Prompt` (message history), `LLModel`,
+  tool descriptors, the `Message.Assistant` response and its `ResponseMetaInfo` token counts →
+  one `modelRequests` entry per LLM call.
+- `onAgentCompleted` / `onAgentExecutionFailed` → `Finished` / `Fatal` result, then the POST.
+
+`KoogRunMapper.kt` maps Koog's `Message`/`MessagePart`/`ToolDescriptor` types onto the Aigentic
+DTOs in `PlatformRunDto.kt`.
+
+## What the test proves
+
+`AigenticPlatformExporterTest` runs a **real Koog agent** (LLM mocked with Koog's `getMockExecutor`,
+the platform mocked with a Ktor `MockEngine`), then asserts that exactly one `RunDto` was POSTed to
+`/gateway/runs` containing the system prompt, the assistant response, a `modelRequests` entry, and a
+`FinishedResultDto`.
+
+```bash
+# from the repository root
+./gradlew -p poc/koog-platform test
+```
+
+## Why this is an isolated build (important finding)
+
+Koog `1.0.0` is built with **Kotlin 2.3.10**; Aigentic is on **Kotlin 2.1.10**. Kotlin metadata is
+not forward-compatible, so a Kotlin-2.1.10 build cannot compile against Koog's 2.3.10 artifacts.
+This PoC is therefore a **standalone Gradle build** (its own `settings.gradle.kts`, Kotlin 2.3.10)
+that is *not* part of the main Aigentic build, so it does not affect `./gradlew build`.
+
+`PlatformRunDto.kt` reproduces the `gateway.ws` contract locally for the same reason. A production
+integration would instead reuse the Wirespec-generated `RunDto`/`Gateway` client from the published
+`community.flock.aigentic:platform` artifact (which a Kotlin ≥ 2.3 consumer can read), or align the
+Kotlin versions of the two projects.

--- a/poc/koog-platform/README.md
+++ b/poc/koog-platform/README.md
@@ -56,6 +56,38 @@ the platform mocked with a Ktor `MockEngine`), then asserts that exactly one `Ru
 ./gradlew -p poc/koog-platform test
 ```
 
+## Message-type compatibility (Koog ↔ Aigentic Platform)
+
+The Aigentic `MessageDto` union and Koog's message model line up well. Mapping
+(`KoogRunMapper.kt`):
+
+| Aigentic `MessageDto`        | Koog source                                                        | Status |
+|------------------------------|--------------------------------------------------------------------|--------|
+| `SystemPromptMessageDto`     | `Message.System`                                                   | ✅ 1:1 |
+| `TextMessageDto`             | `MessagePart.Text` (User → Agent, Assistant → Model)               | ✅ 1:1 |
+| `ToolCallsMessageDto`        | `MessagePart.Tool.Call` (on `Message.Assistant`)                   | ✅ 1:1 |
+| `ToolResultMessageDto`       | `MessagePart.Tool.Result` (on `Message.User`)                      | ✅ 1:1 |
+| `UrlMessageDto`              | `MessagePart.Attachment` + `AttachmentContent.URL`                 | ✅ with MIME caveat |
+| `Base64MessageDto`           | `MessagePart.Attachment` + `AttachmentContent.Binary` (`asBase64()`) | ✅ with MIME caveat |
+| `StructuredOutputMessageDto` | no distinct Koog type — structured output is an `Assistant` text driven by `LLMParams.schema` | ⚠️ policy mapping |
+
+Two caveats:
+
+1. **MIME-type subset.** Aigentic's `MimeTypeDto` is a fixed set — `IMAGE_{JPEG,PNG,WEBP,HEIC,HEIF}`
+   and `APPLICATION_PDF`. Koog allows *any* `mimeType` string and also `Image`/`Video`/`Audio`/`File`
+   sources. So a Koog attachment is publishable only when its MIME type is one of those six; anything
+   else (video, audio, gif, …) has no representation in the current contract and is **skipped** by the
+   mapper (`toMimeTypeDto()` returns `null`). Supporting more would require extending `MimeTypeDto` in
+   `gateway.ws`. Koog's `Reasoning` parts (thinking) likewise have no Aigentic message type and are dropped.
+
+2. **Structured output.** Aigentic has a dedicated `StructuredOutputMessageDto`, but Koog has no
+   distinct structured-output message — it is a normal `Message.Assistant` whose text is JSON (produced
+   via `LLMParams.schema`). It maps to `TextMessageDto` by default; emitting `StructuredOutputMessageDto`
+   would be a policy choice (e.g. "when a response schema is configured, treat the final assistant
+   message as structured output").
+
+`KoogRunMapperTest` covers the supported types end-to-end and asserts the unsupported-MIME skip.
+
 ## Why this is an isolated build (important finding)
 
 Koog `1.0.0` is built with **Kotlin 2.3.10**; Aigentic is on **Kotlin 2.1.10**. Kotlin metadata is

--- a/poc/koog-platform/README.md
+++ b/poc/koog-platform/README.md
@@ -69,7 +69,7 @@ The Aigentic `MessageDto` union and Koog's message model line up well. Mapping
 | `ToolResultMessageDto`       | `MessagePart.Tool.Result` (on `Message.User`)                      | ✅ 1:1 |
 | `UrlMessageDto`              | `MessagePart.Attachment` + `AttachmentContent.URL`                 | ✅ with MIME caveat |
 | `Base64MessageDto`           | `MessagePart.Attachment` + `AttachmentContent.Binary` (`asBase64()`) | ✅ with MIME caveat |
-| `StructuredOutputMessageDto` | no distinct Koog type — structured output is an `Assistant` text driven by `LLMParams.schema` | ⚠️ policy mapping |
+| `StructuredOutputMessageDto` | the final `Message.Assistant` when the agent has a typed (non-`String`) output | ✅ (see Structured output) |
 
 Two caveats:
 
@@ -136,9 +136,20 @@ val extract by node<String, Result<StructuredResponse<Invoice>>> {
 }
 ```
 
-**Mapping to the platform:** the structured result becomes `FinishedResultDto.response` (the JSON output),
-and the same JSON also appears in `messages` as the assistant message. `StructuredOutputExporterTest`
-runs exactly this flow (with a mocked LLM) and asserts the published `RunDto` carries the typed invoice.
+**Feature parity with Aigentic.** Aigentic treats an agent as a *structured-output agent* when it has a
+typed response and no tools (`isStructuredOutputAgent()` = `tools.isEmpty() && responseParameter != null`),
+in which case the final answer is published as a `StructuredOutputMessageDto` and `config.responseJsonSchema`
+is set. The exporter mirrors this: it detects structured output from the agent's typed result
+(`onAgentCompleted.result !is String`) and then
+
+- emits the final assistant message as `StructuredOutputMessageDto` (Model sender) rather than `TextMessageDto`,
+- sets `FinishedResultDto.response` to the structured JSON,
+- sets `config.responseJsonSchema` from `prompt.params.schema` when the model uses native structured output.
+
+`StructuredOutputExporterTest` runs the full PDF-invoice flow end-to-end (mocked LLM): a real PDF
+`MessagePart.Attachment` is sent in the user message, and the published `RunDto` is asserted to contain a
+`Base64MessageDto` (`APPLICATION_PDF`) for the document and a `StructuredOutputMessageDto` carrying the typed
+invoice — the same shape an equivalent Aigentic run would publish.
 
 ## Why this is an isolated build (important finding)
 

--- a/poc/koog-platform/README.md
+++ b/poc/koog-platform/README.md
@@ -151,6 +151,36 @@ is set. The exporter mirrors this: it detects structured output from the agent's
 `Base64MessageDto` (`APPLICATION_PDF`) for the document and a `StructuredOutputMessageDto` carrying the typed
 invoice — the same shape an equivalent Aigentic run would publish.
 
+## Message categories (`context` vs `start()` vs execution)
+
+Aigentic stamps each message with a `MessageCategoryDto` based on *where it came from*
+(`AgentExecutor.seedInitialMessages`):
+
+| Category         | Aigentic origin                                   | Koog equivalent |
+|------------------|---------------------------------------------------|-----------------|
+| `SYSTEM_PROMPT`  | the system prompt                                 | `Message.System` |
+| `CONFIG_CONTEXT` | `context { … }` (set at agent definition, every run) | the base `AIAgentConfig.prompt` (system + seeded context) |
+| `RUN_CONTEXT`    | `start(input, attachments)` (per invocation)      | content added for the run, before the first model turn |
+| `EXECUTION`      | messages produced during the loop                 | everything from the first `Message.Assistant` onward |
+| `EXAMPLE`        | example runs                                       | (set explicitly via metadata) |
+
+**Yes — you can add attachments in different places in Koog, and they are distinguishable.** A PDF can
+live in (a) the **config prompt** (`AIAgentConfig.prompt`, the analog of `context { }` — present on every
+run), (b) the **run input** (appended by a node from `agent.run(input)`, the analog of `start()`), or (c)
+**mid-execution**. The exporter derives the category from two signals:
+
+1. **Origin (automatic).** The base config prompt is reachable from the event context
+   (`agent.agentConfig.prompt`), so the exporter records its size at `onAgentStarting`. Messages within
+   that prefix are `SYSTEM_PROMPT`/`CONFIG_CONTEXT`; content appended before the first assistant message is
+   `RUN_CONTEXT`; everything after is `EXECUTION`.
+2. **Explicit metadata (override).** Koog messages carry `metaInfo.metadata: JsonObject?`. Tagging a
+   message with `{"aigentic.category": "RUN_CONTEXT"}` (etc.) overrides the positional default — the direct
+   analog of Aigentic choosing the category from the API you call.
+
+`MessageCategoryTest` covers both signals; `StructuredOutputExporterTest` proves it end-to-end by attaching
+a reference image in the config prompt (→ `CONFIG_CONTEXT`) and the invoice PDF in the run (→ `RUN_CONTEXT`)
+and asserting the published `RunDto` distinguishes them.
+
 ## Why this is an isolated build (important finding)
 
 Koog `1.0.0` is built with **Kotlin 2.3.10**; Aigentic is on **Kotlin 2.1.10**. Kotlin metadata is

--- a/poc/koog-platform/build.gradle.kts
+++ b/poc/koog-platform/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    kotlin("jvm") version "2.3.10"
+    kotlin("plugin.serialization") version "2.3.10"
+}
+
+repositories {
+    mavenCentral()
+}
+
+val koogVersion = "1.0.0"
+val ktorVersion = "3.3.3"
+
+dependencies {
+    implementation("ai.koog:agents-core:$koogVersion")
+    implementation("ai.koog:agents-features-event-handler:$koogVersion")
+
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+
+    testImplementation(kotlin("test-junit5"))
+    testImplementation("ai.koog:agents-test:$koogVersion")
+    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/poc/koog-platform/gradle.properties
+++ b/poc/koog-platform/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx4g

--- a/poc/koog-platform/settings.gradle.kts
+++ b/poc/koog-platform/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "koog-platform-poc"

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
@@ -35,7 +35,7 @@ fun GraphAIAgent.FeatureContext.aigenticPlatform(
 ) {
     val collector = RunCollector()
     handleEvents {
-        onAgentStarting { collector.onStart(it.runId) }
+        onAgentStarting { collector.onStart(it.runId, it.agent.agentConfig.prompt.messages.size) }
         onLLMCallStarting { collector.onLlmStart(it.runId) }
         onLLMCallCompleted { collector.onLlmCompleted(it.runId, it.prompt, it.model, it.tools, it.response) }
         onAgentCompleted { event ->
@@ -77,8 +77,11 @@ private suspend fun HttpClient.sendRun(
 private class RunCollector {
     private val runs = mutableMapOf<String, Accumulator>()
 
-    fun onStart(runId: String) {
-        runs[runId] = Accumulator(startedAt = now())
+    fun onStart(
+        runId: String,
+        configPromptSize: Int,
+    ) {
+        runs[runId] = Accumulator(startedAt = now(), configPromptSize = configPromptSize)
     }
 
     fun onLlmStart(runId: String) {
@@ -130,7 +133,11 @@ private class RunCollector {
                     temperature = accumulator.temperature ?: 0.0,
                 ),
             result = result(accumulator.lastResponseText),
-            messages = accumulator.messages.toMessageDtos(structuredFinalResponse = structuredOutput),
+            messages =
+                accumulator.messages.toMessageDtos(
+                    configPromptSize = accumulator.configPromptSize,
+                    structuredFinalResponse = structuredOutput,
+                ),
             modelRequests = accumulator.modelRequests,
         )
     }
@@ -141,6 +148,7 @@ private class RunCollector {
 
     private class Accumulator(
         val startedAt: String,
+        val configPromptSize: Int = 0,
         var model: LLModel? = null,
         var tools: List<ToolDescriptor> = emptyList(),
         var temperature: Double? = null,

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.features.eventHandler.feature.handleEvents
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.basicAuth
@@ -38,14 +39,18 @@ fun GraphAIAgent.FeatureContext.aigenticPlatform(
         onLLMCallStarting { collector.onLlmStart(it.runId) }
         onLLMCallCompleted { collector.onLlmCompleted(it.runId, it.prompt, it.model, it.tools, it.response) }
         onAgentCompleted { event ->
+            val structuredOutput = event.result != null && event.result !is String
             val run =
-                collector.build(event.runId, agentDescription) { responseText ->
+                collector.build(event.runId, agentDescription, structuredOutput) { responseText ->
                     FinishedResultDto("Agent completed", responseText ?: event.result?.toString())
                 }
             if (run != null) httpClient.sendRun(apiUrl, name, secret, run)
         }
         onAgentExecutionFailed { event ->
-            val run = collector.build(event.runId, agentDescription) { FatalResultDto(event.error.message ?: "Unknown error") }
+            val run =
+                collector.build(event.runId, agentDescription, structuredOutput = false) {
+                    FatalResultDto(event.error.message ?: "Unknown error")
+                }
             if (run != null) httpClient.sendRun(apiUrl, name, secret, run)
         }
     }
@@ -93,6 +98,7 @@ private class RunCollector {
         accumulator.temperature = prompt.params.temperature
         accumulator.messages = prompt.messages + listOfNotNull(response)
         accumulator.lastResponseText = response?.textContent()
+        (prompt.params.schema as? LLMParams.Schema.JSON)?.let { accumulator.responseSchemaJson = it.schema.toString() }
         val meta = response?.metaInfo
         accumulator.modelRequests +=
             ModelRequestInfoDto(
@@ -106,6 +112,7 @@ private class RunCollector {
     fun build(
         runId: String,
         agentDescription: String,
+        structuredOutput: Boolean,
         result: (lastResponseText: String?) -> ResultDto,
     ): RunDto? {
         val accumulator = runs.remove(runId) ?: return null
@@ -119,10 +126,11 @@ private class RunCollector {
                     modelIdentifier = accumulator.model?.id ?: "unknown",
                     systemPrompt = systemPrompt,
                     tools = accumulator.tools.toToolDtos(),
+                    responseJsonSchema = accumulator.responseSchemaJson,
                     temperature = accumulator.temperature ?: 0.0,
                 ),
             result = result(accumulator.lastResponseText),
-            messages = accumulator.messages.toMessageDtos(),
+            messages = accumulator.messages.toMessageDtos(structuredFinalResponse = structuredOutput),
             modelRequests = accumulator.modelRequests,
         )
     }
@@ -138,6 +146,7 @@ private class RunCollector {
         var temperature: Double? = null,
         var messages: List<Message> = emptyList(),
         var lastResponseText: String? = null,
+        var responseSchemaJson: String? = null,
         val modelRequests: MutableList<ModelRequestInfoDto> = mutableListOf(),
         val llmCallStarts: ArrayDeque<String> = ArrayDeque(),
     )

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
@@ -38,11 +38,14 @@ fun GraphAIAgent.FeatureContext.aigenticPlatform(
         onLLMCallStarting { collector.onLlmStart(it.runId) }
         onLLMCallCompleted { collector.onLlmCompleted(it.runId, it.prompt, it.model, it.tools, it.response) }
         onAgentCompleted { event ->
-            val run = collector.build(event.runId, agentDescription, FinishedResultDto("Agent completed", event.result?.toString()))
+            val run =
+                collector.build(event.runId, agentDescription) { responseText ->
+                    FinishedResultDto("Agent completed", responseText ?: event.result?.toString())
+                }
             if (run != null) httpClient.sendRun(apiUrl, name, secret, run)
         }
         onAgentExecutionFailed { event ->
-            val run = collector.build(event.runId, agentDescription, FatalResultDto(event.error.message ?: "Unknown error"))
+            val run = collector.build(event.runId, agentDescription) { FatalResultDto(event.error.message ?: "Unknown error") }
             if (run != null) httpClient.sendRun(apiUrl, name, secret, run)
         }
     }
@@ -89,6 +92,7 @@ private class RunCollector {
         accumulator.tools = tools
         accumulator.temperature = prompt.params.temperature
         accumulator.messages = prompt.messages + listOfNotNull(response)
+        accumulator.lastResponseText = response?.textContent()
         val meta = response?.metaInfo
         accumulator.modelRequests +=
             ModelRequestInfoDto(
@@ -102,7 +106,7 @@ private class RunCollector {
     fun build(
         runId: String,
         agentDescription: String,
-        result: ResultDto,
+        result: (lastResponseText: String?) -> ResultDto,
     ): RunDto? {
         val accumulator = runs.remove(runId) ?: return null
         val systemPrompt = accumulator.messages.filterIsInstance<Message.System>().firstOrNull()?.textContent() ?: ""
@@ -117,7 +121,7 @@ private class RunCollector {
                     tools = accumulator.tools.toToolDtos(),
                     temperature = accumulator.temperature ?: 0.0,
                 ),
-            result = result,
+            result = result(accumulator.lastResponseText),
             messages = accumulator.messages.toMessageDtos(),
             modelRequests = accumulator.modelRequests,
         )
@@ -133,6 +137,7 @@ private class RunCollector {
         var tools: List<ToolDescriptor> = emptyList(),
         var temperature: Double? = null,
         var messages: List<Message> = emptyList(),
+        var lastResponseText: String? = null,
         val modelRequests: MutableList<ModelRequestInfoDto> = mutableListOf(),
         val llmCallStarts: ArrayDeque<String> = ArrayDeque(),
     )

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/AigenticPlatformExporter.kt
@@ -1,0 +1,139 @@
+package community.flock.aigentic.koog
+
+import ai.koog.agents.core.agent.GraphAIAgent
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.features.eventHandler.feature.handleEvents
+import ai.koog.prompt.Prompt
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.basicAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import java.time.Instant
+
+const val DEFAULT_PLATFORM_API_URL: String = "https://aigentic-backend-kib53ypjwq-ez.a.run.app/"
+
+/**
+ * Installs an [ai.koog.agents.features.eventHandler.feature.EventHandler] that captures the
+ * agent run and publishes it to the Aigentic Platform (`POST RunDto -> /gateway/runs`) on completion.
+ *
+ * This is the Koog-side equivalent of Aigentic's automatic `publishRun` call: it reuses Koog's
+ * public `handleEvents` hooks to collect everything the platform contract needs.
+ */
+fun GraphAIAgent.FeatureContext.aigenticPlatform(
+    name: String,
+    secret: String,
+    apiUrl: String = DEFAULT_PLATFORM_API_URL,
+    httpClient: HttpClient = defaultAigenticHttpClient(),
+    agentDescription: String = "Koog agent",
+) {
+    val collector = RunCollector()
+    handleEvents {
+        onAgentStarting { collector.onStart(it.runId) }
+        onLLMCallStarting { collector.onLlmStart(it.runId) }
+        onLLMCallCompleted { collector.onLlmCompleted(it.runId, it.prompt, it.model, it.tools, it.response) }
+        onAgentCompleted { event ->
+            val run = collector.build(event.runId, agentDescription, FinishedResultDto("Agent completed", event.result?.toString()))
+            if (run != null) httpClient.sendRun(apiUrl, name, secret, run)
+        }
+        onAgentExecutionFailed { event ->
+            val run = collector.build(event.runId, agentDescription, FatalResultDto(event.error.message ?: "Unknown error"))
+            if (run != null) httpClient.sendRun(apiUrl, name, secret, run)
+        }
+    }
+}
+
+fun defaultAigenticHttpClient(): HttpClient =
+    HttpClient {
+        install(ContentNegotiation) { json(aigenticJson) }
+    }
+
+private suspend fun HttpClient.sendRun(
+    apiUrl: String,
+    name: String,
+    secret: String,
+    run: RunDto,
+) {
+    post(apiUrl.trimEnd('/') + "/gateway/runs") {
+        contentType(ContentType.Application.Json)
+        basicAuth(name, secret)
+        setBody(run)
+    }
+}
+
+private class RunCollector {
+    private val runs = mutableMapOf<String, Accumulator>()
+
+    fun onStart(runId: String) {
+        runs[runId] = Accumulator(startedAt = now())
+    }
+
+    fun onLlmStart(runId: String) {
+        accumulator(runId).llmCallStarts.addLast(now())
+    }
+
+    fun onLlmCompleted(
+        runId: String,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        response: Message.Assistant?,
+    ) {
+        val accumulator = accumulator(runId)
+        accumulator.model = model
+        accumulator.tools = tools
+        accumulator.temperature = prompt.params.temperature
+        accumulator.messages = prompt.messages + listOfNotNull(response)
+        val meta = response?.metaInfo
+        accumulator.modelRequests +=
+            ModelRequestInfoDto(
+                startedAt = accumulator.llmCallStarts.removeFirstOrNull() ?: now(),
+                finishedAt = now(),
+                inputTokenCount = meta?.inputTokensCount ?: 0,
+                outputTokenCount = meta?.outputTokensCount ?: 0,
+            )
+    }
+
+    fun build(
+        runId: String,
+        agentDescription: String,
+        result: ResultDto,
+    ): RunDto? {
+        val accumulator = runs.remove(runId) ?: return null
+        val systemPrompt = accumulator.messages.filterIsInstance<Message.System>().firstOrNull()?.textContent() ?: ""
+        return RunDto(
+            startedAt = accumulator.startedAt,
+            finishedAt = now(),
+            config =
+                ConfigDto(
+                    task = TaskDto(agentDescription, emptyList()),
+                    modelIdentifier = accumulator.model?.id ?: "unknown",
+                    systemPrompt = systemPrompt,
+                    tools = accumulator.tools.toToolDtos(),
+                    temperature = accumulator.temperature ?: 0.0,
+                ),
+            result = result,
+            messages = accumulator.messages.toMessageDtos(),
+            modelRequests = accumulator.modelRequests,
+        )
+    }
+
+    private fun accumulator(runId: String): Accumulator = runs.getOrPut(runId) { Accumulator(now()) }
+
+    private fun now(): String = Instant.now().toString()
+
+    private class Accumulator(
+        val startedAt: String,
+        var model: LLModel? = null,
+        var tools: List<ToolDescriptor> = emptyList(),
+        var temperature: Double? = null,
+        var messages: List<Message> = emptyList(),
+        val modelRequests: MutableList<ModelRequestInfoDto> = mutableListOf(),
+        val llmCallStarts: ArrayDeque<String> = ArrayDeque(),
+    )
+}

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
@@ -4,40 +4,76 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
-internal fun List<Message>.toMessageDtos(structuredFinalResponse: Boolean = false): List<MessageDto> {
+internal const val CATEGORY_METADATA_KEY: String = "aigentic.category"
+
+internal fun List<Message>.toMessageDtos(
+    configPromptSize: Int = 0,
+    structuredFinalResponse: Boolean = false,
+): List<MessageDto> {
+    val firstAssistantIndex = indexOfFirst { it is Message.Assistant }
     val lastAssistantIndex = indexOfLast { it is Message.Assistant }
     return flatMapIndexed { index, message ->
-        message.toMessageDtos(structuredOutput = structuredFinalResponse && index == lastAssistantIndex)
+        val category = message.category(index, configPromptSize, firstAssistantIndex)
+        message.toMessageDtos(category, structuredOutput = structuredFinalResponse && index == lastAssistantIndex)
     }
 }
 
-private fun Message.toMessageDtos(structuredOutput: Boolean): List<MessageDto> {
+private fun Message.category(
+    index: Int,
+    configPromptSize: Int,
+    firstAssistantIndex: Int,
+): MessageCategoryDto {
+    metaInfo.metadata?.categoryOverride()?.let { return it }
+    return when {
+        this is Message.System -> MessageCategoryDto.SYSTEM_PROMPT
+        index < configPromptSize -> MessageCategoryDto.CONFIG_CONTEXT
+        firstAssistantIndex == -1 || index < firstAssistantIndex -> MessageCategoryDto.RUN_CONTEXT
+        else -> MessageCategoryDto.EXECUTION
+    }
+}
+
+private fun JsonObject.categoryOverride(): MessageCategoryDto? =
+    (this[CATEGORY_METADATA_KEY] as? JsonPrimitive)
+        ?.contentOrNull
+        ?.let { name -> runCatching { MessageCategoryDto.valueOf(name) }.getOrNull() }
+
+private fun Message.toMessageDtos(
+    category: MessageCategoryDto,
+    structuredOutput: Boolean,
+): List<MessageDto> {
     val createdAt = metaInfo.timestamp.toString()
     return when (this) {
         is Message.System ->
-            listOf(SystemPromptMessageDto(createdAt, SenderDto.Agent, textContent(), MessageCategoryDto.SYSTEM_PROMPT))
+            listOf(SystemPromptMessageDto(createdAt, SenderDto.Agent, textContent(), category))
 
-        is Message.User -> userDtos(createdAt)
-        is Message.Assistant -> assistantDtos(createdAt, structuredOutput)
+        is Message.User -> userDtos(createdAt, category)
+        is Message.Assistant -> assistantDtos(createdAt, category, structuredOutput)
     }
 }
 
-private fun Message.User.userDtos(createdAt: String): List<MessageDto> {
+private fun Message.User.userDtos(
+    createdAt: String,
+    category: MessageCategoryDto,
+): List<MessageDto> {
     val dtos = mutableListOf<MessageDto>()
     val text = parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }
     if (text.isNotEmpty()) {
-        dtos += TextMessageDto(createdAt, SenderDto.Agent, text, MessageCategoryDto.EXECUTION)
+        dtos += TextMessageDto(createdAt, SenderDto.Agent, text, category)
     }
-    dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Agent) }
+    dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Agent, category) }
     parts.filterIsInstance<MessagePart.Tool.Result>().forEach { result ->
-        dtos += ToolResultMessageDto(createdAt, SenderDto.Agent, result.id ?: "", result.tool, result.output, MessageCategoryDto.EXECUTION)
+        dtos += ToolResultMessageDto(createdAt, SenderDto.Agent, result.id ?: "", result.tool, result.output, category)
     }
     return dtos
 }
 
 private fun Message.Assistant.assistantDtos(
     createdAt: String,
+    category: MessageCategoryDto,
     structuredOutput: Boolean,
 ): List<MessageDto> {
     val dtos = mutableListOf<MessageDto>()
@@ -45,19 +81,19 @@ private fun Message.Assistant.assistantDtos(
     if (text.isNotEmpty()) {
         dtos +=
             if (structuredOutput) {
-                StructuredOutputMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
+                StructuredOutputMessageDto(createdAt, SenderDto.Model, text, category)
             } else {
-                TextMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
+                TextMessageDto(createdAt, SenderDto.Model, text, category)
             }
     }
-    dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Model) }
+    dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Model, category) }
     val calls = parts.filterIsInstance<MessagePart.Tool.Call>()
     if (calls.isNotEmpty()) {
         dtos += ToolCallsMessageDto(
             createdAt,
             SenderDto.Model,
             calls.map { ToolCallDto(it.id ?: "", it.tool, it.args) },
-            MessageCategoryDto.EXECUTION,
+            category,
         )
     }
     return dtos
@@ -66,19 +102,20 @@ private fun Message.Assistant.assistantDtos(
 private fun MessagePart.Attachment.toDto(
     createdAt: String,
     sender: SenderDto,
+    category: MessageCategoryDto,
 ): MessageDto? {
     return when (val content = source.content) {
         is AttachmentContent.PlainText ->
-            TextMessageDto(createdAt, sender, content.text, MessageCategoryDto.EXECUTION)
+            TextMessageDto(createdAt, sender, content.text, category)
 
         is AttachmentContent.URL -> {
             val mimeType = source.mimeType.toMimeTypeDto() ?: return null
-            UrlMessageDto(createdAt, sender, content.url, mimeType, MessageCategoryDto.EXECUTION)
+            UrlMessageDto(createdAt, sender, content.url, mimeType, category)
         }
 
         is AttachmentContent.Binary -> {
             val mimeType = source.mimeType.toMimeTypeDto() ?: return null
-            Base64MessageDto(createdAt, sender, content.asBase64(), mimeType, MessageCategoryDto.EXECUTION)
+            Base64MessageDto(createdAt, sender, content.asBase64(), mimeType, category)
         }
     }
 }

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
@@ -1,6 +1,7 @@
 package community.flock.aigentic.koog
 
 import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
 
@@ -23,6 +24,7 @@ private fun Message.User.userDtos(createdAt: String): List<MessageDto> {
     if (text.isNotEmpty()) {
         dtos += TextMessageDto(createdAt, SenderDto.Agent, text, MessageCategoryDto.EXECUTION)
     }
+    dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Agent) }
     parts.filterIsInstance<MessagePart.Tool.Result>().forEach { result ->
         dtos += ToolResultMessageDto(createdAt, SenderDto.Agent, result.id ?: "", result.tool, result.output, MessageCategoryDto.EXECUTION)
     }
@@ -35,6 +37,7 @@ private fun Message.Assistant.assistantDtos(createdAt: String): List<MessageDto>
     if (text.isNotEmpty()) {
         dtos += TextMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
     }
+    dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Model) }
     val calls = parts.filterIsInstance<MessagePart.Tool.Call>()
     if (calls.isNotEmpty()) {
         dtos += ToolCallsMessageDto(
@@ -46,6 +49,37 @@ private fun Message.Assistant.assistantDtos(createdAt: String): List<MessageDto>
     }
     return dtos
 }
+
+private fun MessagePart.Attachment.toDto(
+    createdAt: String,
+    sender: SenderDto,
+): MessageDto? {
+    return when (val content = source.content) {
+        is AttachmentContent.PlainText ->
+            TextMessageDto(createdAt, sender, content.text, MessageCategoryDto.EXECUTION)
+
+        is AttachmentContent.URL -> {
+            val mimeType = source.mimeType.toMimeTypeDto() ?: return null
+            UrlMessageDto(createdAt, sender, content.url, mimeType, MessageCategoryDto.EXECUTION)
+        }
+
+        is AttachmentContent.Binary -> {
+            val mimeType = source.mimeType.toMimeTypeDto() ?: return null
+            Base64MessageDto(createdAt, sender, content.asBase64(), mimeType, MessageCategoryDto.EXECUTION)
+        }
+    }
+}
+
+private fun String.toMimeTypeDto(): MimeTypeDto? =
+    when (lowercase()) {
+        "image/jpeg", "image/jpg" -> MimeTypeDto.IMAGE_JPEG
+        "image/png" -> MimeTypeDto.IMAGE_PNG
+        "image/webp" -> MimeTypeDto.IMAGE_WEBP
+        "image/heic" -> MimeTypeDto.IMAGE_HEIC
+        "image/heif" -> MimeTypeDto.IMAGE_HEIF
+        "application/pdf" -> MimeTypeDto.APPLICATION_PDF
+        else -> null
+    }
 
 internal fun List<ToolDescriptor>.toToolDtos(): List<ToolDto> =
     map { tool ->

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
@@ -5,16 +5,21 @@ import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
 
-internal fun List<Message>.toMessageDtos(): List<MessageDto> = flatMap { it.toMessageDtos() }
+internal fun List<Message>.toMessageDtos(structuredFinalResponse: Boolean = false): List<MessageDto> {
+    val lastAssistantIndex = indexOfLast { it is Message.Assistant }
+    return flatMapIndexed { index, message ->
+        message.toMessageDtos(structuredOutput = structuredFinalResponse && index == lastAssistantIndex)
+    }
+}
 
-private fun Message.toMessageDtos(): List<MessageDto> {
+private fun Message.toMessageDtos(structuredOutput: Boolean): List<MessageDto> {
     val createdAt = metaInfo.timestamp.toString()
     return when (this) {
         is Message.System ->
             listOf(SystemPromptMessageDto(createdAt, SenderDto.Agent, textContent(), MessageCategoryDto.SYSTEM_PROMPT))
 
         is Message.User -> userDtos(createdAt)
-        is Message.Assistant -> assistantDtos(createdAt)
+        is Message.Assistant -> assistantDtos(createdAt, structuredOutput)
     }
 }
 
@@ -31,11 +36,19 @@ private fun Message.User.userDtos(createdAt: String): List<MessageDto> {
     return dtos
 }
 
-private fun Message.Assistant.assistantDtos(createdAt: String): List<MessageDto> {
+private fun Message.Assistant.assistantDtos(
+    createdAt: String,
+    structuredOutput: Boolean,
+): List<MessageDto> {
     val dtos = mutableListOf<MessageDto>()
     val text = parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }
     if (text.isNotEmpty()) {
-        dtos += TextMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
+        dtos +=
+            if (structuredOutput) {
+                StructuredOutputMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
+            } else {
+                TextMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
+            }
     }
     dtos += parts.filterIsInstance<MessagePart.Attachment>().mapNotNull { it.toDto(createdAt, SenderDto.Model) }
     val calls = parts.filterIsInstance<MessagePart.Tool.Call>()

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/KoogRunMapper.kt
@@ -1,0 +1,59 @@
+package community.flock.aigentic.koog
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
+
+internal fun List<Message>.toMessageDtos(): List<MessageDto> = flatMap { it.toMessageDtos() }
+
+private fun Message.toMessageDtos(): List<MessageDto> {
+    val createdAt = metaInfo.timestamp.toString()
+    return when (this) {
+        is Message.System ->
+            listOf(SystemPromptMessageDto(createdAt, SenderDto.Agent, textContent(), MessageCategoryDto.SYSTEM_PROMPT))
+
+        is Message.User -> userDtos(createdAt)
+        is Message.Assistant -> assistantDtos(createdAt)
+    }
+}
+
+private fun Message.User.userDtos(createdAt: String): List<MessageDto> {
+    val dtos = mutableListOf<MessageDto>()
+    val text = parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }
+    if (text.isNotEmpty()) {
+        dtos += TextMessageDto(createdAt, SenderDto.Agent, text, MessageCategoryDto.EXECUTION)
+    }
+    parts.filterIsInstance<MessagePart.Tool.Result>().forEach { result ->
+        dtos += ToolResultMessageDto(createdAt, SenderDto.Agent, result.id ?: "", result.tool, result.output, MessageCategoryDto.EXECUTION)
+    }
+    return dtos
+}
+
+private fun Message.Assistant.assistantDtos(createdAt: String): List<MessageDto> {
+    val dtos = mutableListOf<MessageDto>()
+    val text = parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }
+    if (text.isNotEmpty()) {
+        dtos += TextMessageDto(createdAt, SenderDto.Model, text, MessageCategoryDto.EXECUTION)
+    }
+    val calls = parts.filterIsInstance<MessagePart.Tool.Call>()
+    if (calls.isNotEmpty()) {
+        dtos += ToolCallsMessageDto(
+            createdAt,
+            SenderDto.Model,
+            calls.map { ToolCallDto(it.id ?: "", it.tool, it.args) },
+            MessageCategoryDto.EXECUTION,
+        )
+    }
+    return dtos
+}
+
+internal fun List<ToolDescriptor>.toToolDtos(): List<ToolDto> =
+    map { tool ->
+        ToolDto(
+            name = tool.name,
+            description = tool.description,
+            parameters =
+                tool.requiredParameters.map { ParameterDto(it.name, it.description, true, it.type.name) } +
+                    tool.optionalParameters.map { ParameterDto(it.name, it.description, false, it.type.name) },
+        )
+    }

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/PlatformRunDto.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/PlatformRunDto.kt
@@ -79,6 +79,8 @@ enum class SenderDto { Agent, Model }
 
 enum class MessageCategoryDto { SYSTEM_PROMPT, CONFIG_CONTEXT, RUN_CONTEXT, EXAMPLE, EXECUTION }
 
+enum class MimeTypeDto { IMAGE_JPEG, IMAGE_PNG, IMAGE_WEBP, IMAGE_HEIC, IMAGE_HEIF, APPLICATION_PDF }
+
 @Serializable
 sealed interface MessageDto {
     val createdAt: String
@@ -120,6 +122,35 @@ data class ToolResultMessageDto(
     override val sender: SenderDto,
     val toolCallId: String,
     val toolName: String,
+    val response: String,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+@SerialName("UrlMessageDto")
+data class UrlMessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
+    val url: String,
+    val mimeType: MimeTypeDto,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+@SerialName("Base64MessageDto")
+data class Base64MessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
+    val base64Content: String,
+    val mimeType: MimeTypeDto,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+@SerialName("StructuredOutputMessageDto")
+data class StructuredOutputMessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
     val response: String,
     override val category: MessageCategoryDto? = null,
 ) : MessageDto

--- a/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/PlatformRunDto.kt
+++ b/poc/koog-platform/src/main/kotlin/community/flock/aigentic/koog/PlatformRunDto.kt
@@ -1,0 +1,155 @@
+package community.flock.aigentic.koog
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Data classes mirroring the Aigentic Platform contract defined in
+ * `src/platform/wirespec/gateway.ws` (the `POST RunDto -> /gateway/runs` endpoint).
+ *
+ * In a production integration these would be the Wirespec-generated types from the
+ * published `community.flock.aigentic:platform` artifact. They are reproduced here so the
+ * proof-of-concept stays self-contained and can build against Koog (Kotlin 2.3.x) without
+ * pulling the Kotlin-2.1.x Aigentic build into the same Gradle build.
+ */
+val aigenticJson: Json =
+    Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+        explicitNulls = false
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
+
+@Serializable
+data class RunDto(
+    val startedAt: String,
+    val finishedAt: String,
+    val config: ConfigDto,
+    val result: ResultDto,
+    val messages: List<MessageDto>,
+    val modelRequests: List<ModelRequestInfoDto>,
+)
+
+@Serializable
+data class ConfigDto(
+    val task: TaskDto,
+    val modelIdentifier: String,
+    val systemPrompt: String,
+    val tools: List<ToolDto>,
+    val exampleRunIds: List<String>? = null,
+    val responseJsonSchema: String? = null,
+    val temperature: Double,
+    val thinkingBudget: Long? = null,
+)
+
+@Serializable
+data class TaskDto(
+    val description: String,
+    val instructions: List<String>,
+)
+
+@Serializable
+data class ToolDto(
+    val name: String,
+    val description: String? = null,
+    val parameters: List<ParameterDto>,
+)
+
+@Serializable
+data class ParameterDto(
+    val name: String,
+    val description: String? = null,
+    val isRequired: Boolean,
+    val paramType: String,
+)
+
+@Serializable
+data class ModelRequestInfoDto(
+    val startedAt: String,
+    val finishedAt: String,
+    val inputTokenCount: Int,
+    val outputTokenCount: Int,
+    val thinkingOutputTokenCount: Int? = null,
+    val cachedInputTokenCount: Int? = null,
+)
+
+enum class SenderDto { Agent, Model }
+
+enum class MessageCategoryDto { SYSTEM_PROMPT, CONFIG_CONTEXT, RUN_CONTEXT, EXAMPLE, EXECUTION }
+
+@Serializable
+sealed interface MessageDto {
+    val createdAt: String
+    val sender: SenderDto
+    val category: MessageCategoryDto?
+}
+
+@Serializable
+@SerialName("SystemPromptMessageDto")
+data class SystemPromptMessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
+    val prompt: String,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+@SerialName("TextMessageDto")
+data class TextMessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
+    val text: String,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+@SerialName("ToolCallsMessageDto")
+data class ToolCallsMessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
+    val toolCalls: List<ToolCallDto>,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+@SerialName("ToolResultMessageDto")
+data class ToolResultMessageDto(
+    override val createdAt: String,
+    override val sender: SenderDto,
+    val toolCallId: String,
+    val toolName: String,
+    val response: String,
+    override val category: MessageCategoryDto? = null,
+) : MessageDto
+
+@Serializable
+data class ToolCallDto(
+    val id: String,
+    val name: String,
+    val arguments: String,
+    val expectedArguments: String? = null,
+)
+
+@Serializable
+sealed interface ResultDto
+
+@Serializable
+@SerialName("FinishedResultDto")
+data class FinishedResultDto(
+    val description: String,
+    val response: String? = null,
+) : ResultDto
+
+@Serializable
+@SerialName("StuckResultDto")
+data class StuckResultDto(
+    val reason: String,
+) : ResultDto
+
+@Serializable
+@SerialName("FatalResultDto")
+data class FatalResultDto(
+    val message: String,
+) : ResultDto

--- a/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/AigenticPlatformExporterTest.kt
+++ b/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/AigenticPlatformExporterTest.kt
@@ -1,0 +1,86 @@
+package community.flock.aigentic.koog
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AigenticPlatformExporterTest {
+    @Test
+    fun `koog agent run is published to the aigentic platform as a RunDto`() =
+        runTest {
+            val capturedPaths = mutableListOf<String>()
+            val capturedBodies = mutableListOf<String>()
+
+            val mockEngine =
+                MockEngine { request ->
+                    capturedPaths += request.url.encodedPath
+                    capturedBodies += (request.body as TextContent).text
+                    respond(content = "", status = HttpStatusCode.Created)
+                }
+
+            val httpClient =
+                HttpClient(mockEngine) {
+                    install(ContentNegotiation) { json(aigenticJson) }
+                }
+
+            val mockExecutor =
+                getMockExecutor {
+                    mockLLMAnswer("The answer is 42.").asDefaultResponse
+                }
+
+            val model =
+                LLModel(
+                    provider = LLMProvider.OpenAI,
+                    id = "gpt-4o",
+                    capabilities = listOf(LLMCapability.Completion, LLMCapability.Tools, LLMCapability.Temperature),
+                )
+
+            val agent =
+                AIAgent(
+                    promptExecutor = mockExecutor,
+                    llmModel = model,
+                    systemPrompt = "You are a helpful assistant.",
+                    temperature = 0.0,
+                ) {
+                    aigenticPlatform(
+                        name = "user",
+                        secret = "secret",
+                        apiUrl = "https://platform.test/",
+                        httpClient = httpClient,
+                    )
+                }
+
+            agent.run("What is the answer?")
+
+            assertEquals(1, capturedPaths.size, "Expected exactly one run to be published")
+            assertEquals("/gateway/runs", capturedPaths.single())
+
+            val run = aigenticJson.decodeFromString<RunDto>(capturedBodies.single())
+
+            assertEquals("gpt-4o", run.config.modelIdentifier)
+            assertEquals("You are a helpful assistant.", run.config.systemPrompt)
+            assertTrue(run.messages.any { it is SystemPromptMessageDto }, "Run should contain the system prompt message")
+            assertTrue(
+                run.messages.any { it is TextMessageDto && it.sender == SenderDto.Model && it.text.contains("42") },
+                "Run should contain the assistant's response",
+            )
+            assertTrue(run.modelRequests.isNotEmpty(), "Run should record at least one model request")
+
+            val result = run.result
+            assertTrue(result is FinishedResultDto, "Run should finish successfully")
+            assertEquals("The answer is 42.", result.response)
+        }
+}

--- a/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/KoogRunMapperTest.kt
+++ b/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/KoogRunMapperTest.kt
@@ -1,0 +1,75 @@
+package community.flock.aigentic.koog
+
+import ai.koog.prompt.message.AttachmentContent
+import ai.koog.prompt.message.AttachmentSource
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KoogRunMapperTest {
+    @Test
+    fun `maps the supported aigentic message types from koog messages`() {
+        val system = Message.System("You are helpful.", RequestMetaInfo.Empty)
+        val user =
+            Message.User(
+                parts =
+                    listOf(
+                        MessagePart.Text("Describe these"),
+                        MessagePart.Attachment(AttachmentSource.Image(AttachmentContent.URL("https://example.com/cat.png"), format = "png")),
+                        MessagePart.Attachment(AttachmentSource.File(AttachmentContent.Binary.Base64("JVBERi0="), format = "pdf", mimeType = "application/pdf")),
+                    ),
+                metaInfo = RequestMetaInfo.Empty,
+            )
+        val assistant =
+            Message.Assistant(
+                parts =
+                    listOf(
+                        MessagePart.Text("Here you go"),
+                        MessagePart.Tool.Call(id = "call-1", tool = "lookup", args = """{"q":"x"}"""),
+                    ),
+                metaInfo = ResponseMetaInfo.Empty,
+            )
+        val toolResult =
+            Message.User(
+                parts = listOf(MessagePart.Tool.Result(id = "call-1", tool = "lookup", output = "found")),
+                metaInfo = RequestMetaInfo.Empty,
+            )
+
+        val dtos = listOf(system, user, assistant, toolResult).toMessageDtos()
+
+        assertTrue(dtos.any { it is SystemPromptMessageDto })
+        assertTrue(dtos.any { it is TextMessageDto && it.sender == SenderDto.Agent && it.text == "Describe these" })
+        assertTrue(dtos.any { it is TextMessageDto && it.sender == SenderDto.Model && it.text == "Here you go" })
+
+        val url = dtos.filterIsInstance<UrlMessageDto>().single()
+        assertEquals("https://example.com/cat.png", url.url)
+        assertEquals(MimeTypeDto.IMAGE_PNG, url.mimeType)
+
+        val base64 = dtos.filterIsInstance<Base64MessageDto>().single()
+        assertEquals("JVBERi0=", base64.base64Content)
+        assertEquals(MimeTypeDto.APPLICATION_PDF, base64.mimeType)
+
+        val toolCalls = dtos.filterIsInstance<ToolCallsMessageDto>().single()
+        assertEquals("lookup", toolCalls.toolCalls.single().name)
+
+        val toolResultDto = dtos.filterIsInstance<ToolResultMessageDto>().single()
+        assertEquals("found", toolResultDto.response)
+    }
+
+    @Test
+    fun `skips attachments whose mime type the platform contract does not support`() {
+        val user =
+            Message.User(
+                parts = listOf(MessagePart.Attachment(AttachmentSource.Video(AttachmentContent.URL("https://example.com/clip.mp4"), format = "mp4"))),
+                metaInfo = RequestMetaInfo.Empty,
+            )
+
+        val dtos = listOf(user).toMessageDtos()
+
+        assertTrue(dtos.none { it is UrlMessageDto || it is Base64MessageDto })
+    }
+}

--- a/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/MessageCategoryTest.kt
+++ b/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/MessageCategoryTest.kt
@@ -1,0 +1,53 @@
+package community.flock.aigentic.koog
+
+import ai.koog.prompt.message.AttachmentContent
+import ai.koog.prompt.message.AttachmentSource
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MessageCategoryTest {
+    @Test
+    fun `categories are derived from where the message originates`() {
+        val system = Message.System("You are helpful.", RequestMetaInfo.Empty)
+        val configDocument =
+            Message.User(
+                listOf(MessagePart.Attachment(AttachmentSource.Image(AttachmentContent.URL("https://example.com/reference.png"), format = "png"))),
+                RequestMetaInfo.Empty,
+            )
+        val runInput = Message.User("Process this document", RequestMetaInfo.Empty)
+        val assistant = Message.Assistant("Processed", ResponseMetaInfo.Empty)
+
+        // The config prompt is [system, configDocument]; the run appends [runInput] then the model replies.
+        val dtos = listOf(system, configDocument, runInput, assistant).toMessageDtos(configPromptSize = 2)
+
+        assertEquals(MessageCategoryDto.SYSTEM_PROMPT, dtos.filterIsInstance<SystemPromptMessageDto>().single().category)
+        assertEquals(MessageCategoryDto.CONFIG_CONTEXT, dtos.filterIsInstance<UrlMessageDto>().single().category)
+        assertEquals(
+            MessageCategoryDto.RUN_CONTEXT,
+            dtos.filterIsInstance<TextMessageDto>().single { it.sender == SenderDto.Agent }.category,
+        )
+        assertEquals(
+            MessageCategoryDto.EXECUTION,
+            dtos.filterIsInstance<TextMessageDto>().single { it.sender == SenderDto.Model }.category,
+        )
+    }
+
+    @Test
+    fun `an explicit metadata category overrides the positional default`() {
+        val tagged =
+            Message.User(
+                listOf(MessagePart.Text("An example exchange")),
+                RequestMetaInfo.Empty.copy(metadata = buildJsonObject { put(CATEGORY_METADATA_KEY, "EXAMPLE") }),
+            )
+
+        val dtos = listOf(tagged).toMessageDtos(configPromptSize = 0)
+
+        assertEquals(MessageCategoryDto.EXAMPLE, dtos.filterIsInstance<TextMessageDto>().single().category)
+    }
+}

--- a/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/StructuredOutputExporterTest.kt
+++ b/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/StructuredOutputExporterTest.kt
@@ -1,13 +1,17 @@
 package community.flock.aigentic.koog
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
-import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.message.AttachmentContent
+import ai.koog.prompt.message.AttachmentSource
+import ai.koog.prompt.message.MessagePart
+import ai.koog.prompt.structure.StructuredResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -40,7 +44,7 @@ data class Invoice(
 
 class StructuredOutputExporterTest {
     @Test
-    fun `structured request-response agent publishes its typed result as a RunDto`() =
+    fun `pdf invoice is extracted as structured output and published with feature parity`() =
         runTest {
             val capturedBodies = mutableListOf<String>()
             val mockEngine =
@@ -52,7 +56,6 @@ class StructuredOutputExporterTest {
 
             val invoiceJson =
                 """{"number":"INV-42","total":42.0,"items":[{"description":"Widget","amount":42.0}]}"""
-
             val mockExecutor = getMockExecutor { mockLLMAnswer(invoiceJson).asDefaultResponse }
 
             val model =
@@ -62,9 +65,25 @@ class StructuredOutputExporterTest {
                     capabilities = listOf(LLMCapability.Completion, LLMCapability.Temperature),
                 )
 
+            val pdfBytes = "%PDF-1.4 fake invoice bytes".encodeToByteArray()
+
             val extractInvoice =
-                strategy<String, Invoice>("invoice-extraction") {
-                    val extract by nodeLLMRequestStructured<Invoice>()
+                strategy<ByteArray, Invoice>("invoice-extraction") {
+                    val extract by node<ByteArray, Result<StructuredResponse<Invoice>>>("extract") { pdf ->
+                        llm.writeSession {
+                            appendPrompt {
+                                user(
+                                    listOf(
+                                        MessagePart.Text("Extract the invoice from the attached document."),
+                                        MessagePart.Attachment(
+                                            AttachmentSource.File(AttachmentContent.Binary.Bytes(pdf), format = "pdf", mimeType = "application/pdf"),
+                                        ),
+                                    ),
+                                )
+                            }
+                            requestLLMStructured<Invoice>()
+                        }
+                    }
                     edge(nodeStart forwardTo extract)
                     edge(extract forwardTo nodeFinish transformed { it.getOrThrow().data })
                 }
@@ -85,19 +104,23 @@ class StructuredOutputExporterTest {
                     )
                 }
 
-            val invoice: Invoice = agent.run("<invoice document>")
+            val invoice: Invoice = agent.run(pdfBytes)
 
             assertEquals("INV-42", invoice.number)
             assertEquals("Widget", invoice.items.single().description)
 
             val run = aigenticJson.decodeFromString<RunDto>(capturedBodies.single())
 
+            val pdfMessage = run.messages.filterIsInstance<Base64MessageDto>().single()
+            assertEquals(MimeTypeDto.APPLICATION_PDF, pdfMessage.mimeType)
+
+            val structured = run.messages.filterIsInstance<StructuredOutputMessageDto>().single()
+            assertEquals(SenderDto.Model, structured.sender)
+            assertTrue(structured.response.contains("INV-42"))
+            assertTrue(run.messages.none { it is TextMessageDto && it.sender == SenderDto.Model })
+
             val result = run.result
-            assertTrue(result is FinishedResultDto, "Structured run should finish successfully")
-            assertTrue(result.response!!.contains("INV-42"), "The structured output should be published as the run result")
-            assertTrue(
-                run.messages.any { it is TextMessageDto && it.sender == SenderDto.Model && it.text.contains("INV-42") },
-                "The structured JSON should appear as the assistant message",
-            )
+            assertTrue(result is FinishedResultDto)
+            assertTrue(result.response!!.contains("INV-42"))
         }
 }

--- a/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/StructuredOutputExporterTest.kt
+++ b/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/StructuredOutputExporterTest.kt
@@ -1,0 +1,103 @@
+package community.flock.aigentic.koog
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.agents.testing.tools.getMockExecutor
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Serializable
+@SerialName("Invoice")
+@LLMDescription("An invoice with its line items")
+data class Invoice(
+    @property:LLMDescription("Invoice number") val number: String,
+    @property:LLMDescription("Total amount due") val total: Double,
+    @property:LLMDescription("Line items on the invoice") val items: List<LineItem>,
+) {
+    @Serializable
+    @SerialName("LineItem")
+    data class LineItem(
+        @property:LLMDescription("Description of the item") val description: String,
+        @property:LLMDescription("Amount for the item") val amount: Double,
+    )
+}
+
+class StructuredOutputExporterTest {
+    @Test
+    fun `structured request-response agent publishes its typed result as a RunDto`() =
+        runTest {
+            val capturedBodies = mutableListOf<String>()
+            val mockEngine =
+                MockEngine { request ->
+                    capturedBodies += (request.body as TextContent).text
+                    respond(content = "", status = HttpStatusCode.Created)
+                }
+            val httpClient = HttpClient(mockEngine) { install(ContentNegotiation) { json(aigenticJson) } }
+
+            val invoiceJson =
+                """{"number":"INV-42","total":42.0,"items":[{"description":"Widget","amount":42.0}]}"""
+
+            val mockExecutor = getMockExecutor { mockLLMAnswer(invoiceJson).asDefaultResponse }
+
+            val model =
+                LLModel(
+                    provider = LLMProvider.OpenAI,
+                    id = "gpt-4o",
+                    capabilities = listOf(LLMCapability.Completion, LLMCapability.Temperature),
+                )
+
+            val extractInvoice =
+                strategy<String, Invoice>("invoice-extraction") {
+                    val extract by nodeLLMRequestStructured<Invoice>()
+                    edge(nodeStart forwardTo extract)
+                    edge(extract forwardTo nodeFinish transformed { it.getOrThrow().data })
+                }
+
+            val agent =
+                AIAgent(
+                    promptExecutor = mockExecutor,
+                    llmModel = model,
+                    strategy = extractInvoice,
+                    systemPrompt = "Extract the structured invoice from the document.",
+                    temperature = 0.0,
+                ) {
+                    aigenticPlatform(
+                        name = "user",
+                        secret = "secret",
+                        apiUrl = "https://platform.test/",
+                        httpClient = httpClient,
+                    )
+                }
+
+            val invoice: Invoice = agent.run("<invoice document>")
+
+            assertEquals("INV-42", invoice.number)
+            assertEquals("Widget", invoice.items.single().description)
+
+            val run = aigenticJson.decodeFromString<RunDto>(capturedBodies.single())
+
+            val result = run.result
+            assertTrue(result is FinishedResultDto, "Structured run should finish successfully")
+            assertTrue(result.response!!.contains("INV-42"), "The structured output should be published as the run result")
+            assertTrue(
+                run.messages.any { it is TextMessageDto && it.sender == SenderDto.Model && it.text.contains("INV-42") },
+                "The structured JSON should appear as the assistant message",
+            )
+        }
+}

--- a/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/StructuredOutputExporterTest.kt
+++ b/poc/koog-platform/src/test/kotlin/community/flock/aigentic/koog/StructuredOutputExporterTest.kt
@@ -1,10 +1,12 @@
 package community.flock.aigentic.koog
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -88,13 +90,25 @@ class StructuredOutputExporterTest {
                     edge(extract forwardTo nodeFinish transformed { it.getOrThrow().data })
                 }
 
+            // A reference document attached at agent-definition time (Aigentic's `context { }` => CONFIG_CONTEXT).
+            val agentConfig =
+                AIAgentConfig(
+                    prompt =
+                        prompt("invoice-agent") {
+                            system("Extract the structured invoice from the document.")
+                            user {
+                                attachment(AttachmentSource.Image(AttachmentContent.URL("https://example.com/reference-invoice.png"), format = "png"))
+                            }
+                        },
+                    model = model,
+                    maxAgentIterations = 5,
+                )
+
             val agent =
                 AIAgent(
                     promptExecutor = mockExecutor,
-                    llmModel = model,
                     strategy = extractInvoice,
-                    systemPrompt = "Extract the structured invoice from the document.",
-                    temperature = 0.0,
+                    agentConfig = agentConfig,
                 ) {
                     aigenticPlatform(
                         name = "user",
@@ -111,11 +125,19 @@ class StructuredOutputExporterTest {
 
             val run = aigenticJson.decodeFromString<RunDto>(capturedBodies.single())
 
+            // The run's PDF (attached during execution from the run input) => RUN_CONTEXT.
             val pdfMessage = run.messages.filterIsInstance<Base64MessageDto>().single()
             assertEquals(MimeTypeDto.APPLICATION_PDF, pdfMessage.mimeType)
+            assertEquals(MessageCategoryDto.RUN_CONTEXT, pdfMessage.category)
+
+            // The reference image from the config prompt => CONFIG_CONTEXT.
+            val referenceImage = run.messages.filterIsInstance<UrlMessageDto>().single()
+            assertEquals(MimeTypeDto.IMAGE_PNG, referenceImage.mimeType)
+            assertEquals(MessageCategoryDto.CONFIG_CONTEXT, referenceImage.category)
 
             val structured = run.messages.filterIsInstance<StructuredOutputMessageDto>().single()
             assertEquals(SenderDto.Model, structured.sender)
+            assertEquals(MessageCategoryDto.EXECUTION, structured.category)
             assertTrue(structured.response.contains("INV-42"))
             assertTrue(run.messages.none { it is TextMessageDto && it.sender == SenderDto.Model })
 


### PR DESCRIPTION
## What & why

Investigates whether **[JetBrains Koog](https://github.com/JetBrains/koog)** can be made to publish its agent runs to the **Aigentic Platform** using the *same* contract Aigentic itself uses, and provides a working proof-of-concept.

**Answer: yes — and no fork/patch of Koog is needed.** This was verified against the real Koog `1.0.0` source, not guessed.

## How Aigentic publishes a run (the contract we target)

After every run, `publishRun` (`src/core/.../agent/AgentExecutor.kt`) makes a single authenticated request when a `platform { … }` is configured:

```
POST RunDto  ->  /gateway/runs        (HTTP Basic Auth; 201 / 401 / 400 / 500)
```

`RunDto` (`src/platform/wirespec/gateway.ws`) carries `startedAt`/`finishedAt`, `config` (task, model identifier, system prompt, tools, temperature…), `result` (Finished/Stuck/Fatal), `messages[]`, and `modelRequests[]` (per-LLM-call token usage). Publishing is not runtime-specific — it is just "build a `RunDto` and POST it".

## How the PoC mirrors it from Koog

Koog's `agents-features-event-handler` exposes the full lifecycle via `handleEvents { … }`. A small `aigenticPlatform(name, secret, …)` extension installs it, collects the run, and POSTs a `RunDto` on completion — the Koog-side equivalent of `publishRun`:

```kotlin
val agent = AIAgent(promptExecutor = executor, llmModel = model, systemPrompt = "…") {
    aigenticPlatform(name = "…", secret = "…")   // publishes the run on completion
}
agent.run("…")
```

Hooks used: `onAgentStarting`, `onLLMCallStarting`/`onLLMCallCompleted` (full `Prompt`, `LLModel`, tool descriptors, the `Message.Assistant` response + its token counts → `modelRequests`), and `onAgentCompleted`/`onAgentExecutionFailed` (→ Finished/Fatal result + POST).

## What's included

- `PlatformRunDto.kt` — DTOs mirroring `gateway.ws`.
- `KoogRunMapper.kt` — maps Koog `Message`/`MessagePart`/`ToolDescriptor` → Aigentic DTOs.
- `AigenticPlatformExporter.kt` — the `aigenticPlatform(...)` EventHandler exporter.
- `AigenticPlatformExporterTest.kt` — runs a **real Koog agent** (LLM mocked via `getMockExecutor`, platform mocked via Ktor `MockEngine`) and asserts exactly one `RunDto` POSTed to `/gateway/runs` containing the system prompt, the assistant response, a `modelRequests` entry, and a `FinishedResultDto`. ✅ passing.

```bash
./gradlew -p poc/koog-platform test
```

## Important: why this is an isolated build

Koog `1.0.0` is built with **Kotlin 2.3.10**; Aigentic is on **Kotlin 2.1.10**. Kotlin metadata is not forward-compatible, so the main (2.1.10) build cannot compile against Koog's artifacts. The PoC is therefore a **standalone Gradle build** under `poc/koog-platform/` (its own `settings.gradle.kts`, Kotlin 2.3.10), is **not** wired into the root build, and does **not** affect `./gradlew build`. `PlatformRunDto.kt` reproduces the contract locally for the same reason.

A production integration would reuse the Wirespec-generated `RunDto`/`Gateway` client from the published `community.flock.aigentic:platform` artifact (readable by a Kotlin ≥ 2.3 consumer) or align the two projects' Kotlin versions.

See `poc/koog-platform/README.md` for full details.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BStcVSYpGtm6cXVy1a7oYA)_