### PR TITLE
feat: attach expected output in the DSL to seed platform evaluation sets

### DIFF
--- a/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/AgentExecutor.kt
+++ b/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/AgentExecutor.kt
@@ -112,11 +112,11 @@ internal suspend inline fun <reified I : Any, reified O : Any> publishRun(
 }
 
 suspend inline fun <reified I : Any, reified O : Any> Agent<I, O>.addToEvaluationSet(
-    runId: RunId,
+    runId: String,
     evaluationSet: String,
     expected: O,
 ): EvaluationSubmitResult =
-    platform?.addToEvaluationSet(runId, evaluationSet, expected)
+    platform?.addToEvaluationSet(RunId(runId), evaluationSet, expected)
         ?: aigenticException("Platform must be configured to add a run to an evaluation set")
 
 suspend inline fun <reified I : Any, reified O : Any> executeAction(action: Action<I, O>): Pair<State, Outcome<O>> {

--- a/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/AgentExecutor.kt
+++ b/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/AgentExecutor.kt
@@ -33,7 +33,9 @@ import community.flock.aigentic.core.message.ToolCall
 import community.flock.aigentic.core.message.asJson
 import community.flock.aigentic.core.message.mapToTextMessages
 import community.flock.aigentic.core.model.ModelResponse
+import community.flock.aigentic.core.platform.EvaluationSubmitResult
 import community.flock.aigentic.core.platform.RunSentResult
+import community.flock.aigentic.core.platform.addToEvaluationSet
 import community.flock.aigentic.core.platform.getRuns
 import community.flock.aigentic.core.platform.sendRun
 import community.flock.aigentic.core.tool.Parameter
@@ -51,6 +53,7 @@ suspend inline fun <reified I : Any, reified O : Any> Agent<I, O>.start(vararg a
 suspend inline fun <reified I : Any, reified O : Any> Agent<I, O>.start(
     input: I? = null,
     vararg attachments: Attachment,
+    expected: Expected<O>? = null,
 ): AgentRun<O> =
     coroutineScope {
         val agent = this@start
@@ -59,13 +62,13 @@ suspend inline fun <reified I : Any, reified O : Any> Agent<I, O>.start(
         val logging = async { state.getStatus().map { it.text }.collect(::println) }
         try {
             val run = executeAction(Initialize(state, agent, input, attachments.toList())).toRun()
-            publishRun(agent, run, state)
-            run
+            val platformRunId = publishRun(agent, run, state, expected)
+            run.copy(platformRunId = platformRunId)
         } catch (e: AigenticException) {
             state.events.emit(AgentStatus.Fatal(e.message))
             val run = (state to Outcome.Fatal(e.message)).toRun<O>()
-            publishRun(agent, run, state)
-            run
+            val platformRunId = publishRun(agent, run, state, expected)
+            run.copy(platformRunId = platformRunId)
         } finally {
             delay(10) // Allow some time for the logging to finish
             logging.cancelAndJoin()
@@ -77,21 +80,44 @@ internal suspend inline fun <reified I : Any, reified O : Any> publishRun(
     agent: Agent<I, O>,
     run: AgentRun<O>,
     state: State,
-) {
-    if (agent.platform != null) {
-        runCatching {
-            agent.platform.sendRun(run, agent)
-        }.onSuccess { result ->
+    expected: Expected<O>?,
+): RunId? {
+    if (agent.platform == null) return null
+    return runCatching {
+        agent.platform.sendRun(run, agent, expected)
+    }.fold(
+        onSuccess = { result ->
             when (result) {
-                RunSentResult.Success -> state.events.emit(AgentStatus.PublishedRunSuccess)
-                RunSentResult.Unauthorized -> state.events.emit(AgentStatus.PublishedRunUnauthorized)
-                is RunSentResult.Error -> state.events.emit(AgentStatus.PublishedRunError(result.message))
+                is RunSentResult.Success -> {
+                    state.events.emit(AgentStatus.PublishedRunSuccess)
+                    result.runId
+                }
+
+                RunSentResult.Unauthorized -> {
+                    state.events.emit(AgentStatus.PublishedRunUnauthorized)
+                    null
+                }
+
+                is RunSentResult.Error -> {
+                    state.events.emit(AgentStatus.PublishedRunError(result.message))
+                    null
+                }
             }
-        }.onFailure { exception ->
+        },
+        onFailure = { exception ->
             state.events.emit(AgentStatus.PublishedRunError(exception.message ?: "Unknown error"))
-        }
-    }
+            null
+        },
+    )
 }
+
+suspend inline fun <reified I : Any, reified O : Any> Agent<I, O>.addToEvaluationSet(
+    runId: RunId,
+    evaluationSet: String,
+    expected: O,
+): EvaluationSubmitResult =
+    platform?.addToEvaluationSet(runId, evaluationSet, expected)
+        ?: aigenticException("Platform must be configured to add a run to an evaluation set")
 
 suspend inline fun <reified I : Any, reified O : Any> executeAction(action: Action<I, O>): Pair<State, Outcome<O>> {
     var currentAction = action

--- a/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/Expected.kt
+++ b/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/Expected.kt
@@ -1,0 +1,6 @@
+package community.flock.aigentic.core.agent
+
+data class Expected<O : Any>(
+    val evaluationSet: String,
+    val output: O,
+)

--- a/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/Run.kt
+++ b/src/core/src/commonMain/kotlin/community/flock/aigentic/core/agent/Run.kt
@@ -25,6 +25,7 @@ data class AgentRun<O : Any>(
     override val modelRequests: List<ModelRequestInfo>,
     val systemPromptMessage: Message.SystemPrompt,
     val exampleRunIds: List<RunId> = emptyList(),
+    val platformRunId: RunId? = null,
 ) : Run<O>()
 
 data class WorkflowRun<O : Any>(
@@ -120,5 +121,6 @@ internal inline fun <reified O : Any> AgentRun<String>.decode(): AgentRun<O> {
         modelRequests = modelRequests,
         exampleRunIds = exampleRunIds,
         systemPromptMessage = systemPromptMessage,
+        platformRunId = platformRunId,
     )
 }

--- a/src/core/src/commonMain/kotlin/community/flock/aigentic/core/platform/Platform.kt
+++ b/src/core/src/commonMain/kotlin/community/flock/aigentic/core/platform/Platform.kt
@@ -71,7 +71,7 @@ suspend inline fun <reified O : Any> Platform.getRuns(tags: List<RunTag>): List<
 
 sealed interface RunSentResult {
     data class Success(
-        val runId: RunId?,
+        val runId: RunId,
     ) : RunSentResult
 
     data object Unauthorized : RunSentResult

--- a/src/core/src/commonMain/kotlin/community/flock/aigentic/core/platform/Platform.kt
+++ b/src/core/src/commonMain/kotlin/community/flock/aigentic/core/platform/Platform.kt
@@ -2,6 +2,7 @@ package community.flock.aigentic.core.platform
 
 import community.flock.aigentic.core.agent.Agent
 import community.flock.aigentic.core.agent.AgentRun
+import community.flock.aigentic.core.agent.Expected
 import community.flock.aigentic.core.agent.RunId
 import community.flock.aigentic.core.agent.RunTag
 import community.flock.aigentic.core.agent.decode
@@ -30,7 +31,15 @@ interface PlatformClient {
         run: AgentRun<O>,
         agent: Agent<I, O>,
         outputSerializer: KSerializer<O>,
+        expected: Expected<O>?,
     ): RunSentResult
+
+    suspend fun <O : Any> addToEvaluationSet(
+        runId: RunId,
+        evaluationSet: String,
+        expected: O,
+        outputSerializer: KSerializer<O>,
+    ): EvaluationSubmitResult
 
     suspend fun getRuns(tags: List<RunTag>): List<Pair<RunId, AgentRun<String>>>
 }
@@ -44,7 +53,14 @@ interface Platform {
 suspend inline fun <reified I : Any, reified O : Any> Platform.sendRun(
     run: AgentRun<O>,
     agent: Agent<I, O>,
-): RunSentResult = client.sendRun(run, agent, serializer<O>())
+    expected: Expected<O>? = null,
+): RunSentResult = client.sendRun(run, agent, serializer<O>(), expected)
+
+suspend inline fun <reified O : Any> Platform.addToEvaluationSet(
+    runId: RunId,
+    evaluationSet: String,
+    expected: O,
+): EvaluationSubmitResult = client.addToEvaluationSet(runId, evaluationSet, expected, serializer<O>())
 
 suspend inline fun <reified O : Any> Platform.getRuns(tags: List<RunTag>): List<Pair<RunId, AgentRun<O>>> =
     client
@@ -54,11 +70,25 @@ suspend inline fun <reified O : Any> Platform.getRuns(tags: List<RunTag>): List<
         }
 
 sealed interface RunSentResult {
-    data object Success : RunSentResult
+    data class Success(
+        val runId: RunId?,
+    ) : RunSentResult
 
     data object Unauthorized : RunSentResult
 
     data class Error(
         val message: String,
     ) : RunSentResult
+}
+
+sealed interface EvaluationSubmitResult {
+    data object Success : EvaluationSubmitResult
+
+    data object Unauthorized : EvaluationSubmitResult
+
+    data object NotFound : EvaluationSubmitResult
+
+    data class Error(
+        val message: String,
+    ) : EvaluationSubmitResult
 }

--- a/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/client/PlatformClient.kt
+++ b/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/client/PlatformClient.kt
@@ -11,7 +11,7 @@ import community.flock.aigentic.core.platform.EvaluationSubmitResult
 import community.flock.aigentic.core.platform.PlatformApiUrl
 import community.flock.aigentic.core.platform.PlatformClient
 import community.flock.aigentic.core.platform.RunSentResult
-import community.flock.aigentic.gateway.wirespec.endpoint.AddToEvaluationSet
+import community.flock.aigentic.gateway.wirespec.endpoint.AddRunAnnotations
 import community.flock.aigentic.gateway.wirespec.endpoint.Gateway
 import community.flock.aigentic.gateway.wirespec.endpoint.GetRuns
 import community.flock.aigentic.gateway.wirespec.model.RunCreatedDto
@@ -51,7 +51,7 @@ import kotlin.reflect.KType
 interface PlatformEndpoints :
     Gateway.Handler,
     GetRuns.Handler,
-    AddToEvaluationSet.Handler
+    AddRunAnnotations.Handler
 
 const val defaultPlatformApiUrl = "https://aigentic-backend-kib53ypjwq-ez.a.run.app/"
 
@@ -70,11 +70,10 @@ class AigenticPlatformClient(
         val request = Gateway.Request(body = runDto)
         return when (val response = endpoints.gateway(request)) {
             is Gateway.Response201 -> {
-                RunSentResult.Success(
-                    response.body.runId
-                        .takeIf { it.isNotBlank() }
-                        ?.let(::RunId),
-                )
+                response.body.runId
+                    .takeIf { it.isNotBlank() }
+                    ?.let { RunSentResult.Success(RunId(it)) }
+                    ?: RunSentResult.Error("Gateway accepted the run but returned no run id")
             }
 
             is Gateway.Response401 -> {
@@ -100,7 +99,7 @@ class AigenticPlatformClient(
         outputSerializer: KSerializer<O>,
     ): EvaluationSubmitResult {
         val request =
-            AddToEvaluationSet.Request(
+            AddRunAnnotations.Request(
                 runId = runId.value,
                 body =
                     RunEvaluationDto(
@@ -108,24 +107,24 @@ class AigenticPlatformClient(
                         expectedResponse = Json.encodeToString(outputSerializer, expected),
                     ),
             )
-        return when (val response = endpoints.addToEvaluationSet(request)) {
-            is AddToEvaluationSet.Response200 -> {
+        return when (val response = endpoints.addRunAnnotations(request)) {
+            is AddRunAnnotations.Response200 -> {
                 EvaluationSubmitResult.Success
             }
 
-            is AddToEvaluationSet.Response401 -> {
+            is AddRunAnnotations.Response401 -> {
                 EvaluationSubmitResult.Unauthorized
             }
 
-            is AddToEvaluationSet.Response404 -> {
+            is AddRunAnnotations.Response404 -> {
                 EvaluationSubmitResult.NotFound
             }
 
-            is AddToEvaluationSet.Response400 -> {
+            is AddRunAnnotations.Response400 -> {
                 EvaluationSubmitResult.Error(response.body.message)
             }
 
-            is AddToEvaluationSet.Response500 -> {
+            is AddRunAnnotations.Response500 -> {
                 EvaluationSubmitResult.Error("${response.body.name} - ${response.body.description}")
             }
         }
@@ -215,8 +214,8 @@ class AigenticPlatformEndpoints(
         val edge = Gateway.Handler.client(serialization)
         val rawRequest = edge.to(request)
         val rawResponse = executeRequest(rawRequest)
-        // Backward compatibility: old gateways respond 201 with an empty body (no RunCreatedDto).
-        // Surface it as a Response201 with an empty runId so the run id stays null instead of throwing.
+        // Backward compatibility: older gateways answer 201 with an empty body (the previous `201 -> Unit`).
+        // Surface it as a 201 with a blank runId so it doesn't throw; sendRun maps the blank id to an Error.
         if (rawResponse.statusCode == 201 && rawResponse.body?.isEmpty() != false) {
             return Gateway.Response201(RunCreatedDto(runId = ""))
         }
@@ -230,8 +229,8 @@ class AigenticPlatformEndpoints(
         return edge.from(rawResponse)
     }
 
-    override suspend fun addToEvaluationSet(request: AddToEvaluationSet.Request): AddToEvaluationSet.Response<*> {
-        val edge = AddToEvaluationSet.Handler.client(serialization)
+    override suspend fun addRunAnnotations(request: AddRunAnnotations.Request): AddRunAnnotations.Response<*> {
+        val edge = AddRunAnnotations.Handler.client(serialization)
         val rawRequest = edge.to(request)
         val rawResponse = executeRequest(rawRequest)
         return edge.from(rawResponse)

--- a/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/client/PlatformClient.kt
+++ b/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/client/PlatformClient.kt
@@ -2,15 +2,20 @@ package community.flock.aigentic.platform.client
 
 import community.flock.aigentic.core.agent.Agent
 import community.flock.aigentic.core.agent.AgentRun
+import community.flock.aigentic.core.agent.Expected
 import community.flock.aigentic.core.agent.RunId
 import community.flock.aigentic.core.agent.RunTag
 import community.flock.aigentic.core.exception.aigenticException
 import community.flock.aigentic.core.platform.Authentication
+import community.flock.aigentic.core.platform.EvaluationSubmitResult
 import community.flock.aigentic.core.platform.PlatformApiUrl
 import community.flock.aigentic.core.platform.PlatformClient
 import community.flock.aigentic.core.platform.RunSentResult
+import community.flock.aigentic.gateway.wirespec.endpoint.AddToEvaluationSet
 import community.flock.aigentic.gateway.wirespec.endpoint.Gateway
 import community.flock.aigentic.gateway.wirespec.endpoint.GetRuns
+import community.flock.aigentic.gateway.wirespec.model.RunCreatedDto
+import community.flock.aigentic.gateway.wirespec.model.RunEvaluationDto
 import community.flock.aigentic.platform.mapper.toDto
 import community.flock.aigentic.platform.mapper.toRun
 import community.flock.wirespec.kotlin.Wirespec
@@ -45,7 +50,8 @@ import kotlin.reflect.KType
 
 interface PlatformEndpoints :
     Gateway.Handler,
-    GetRuns.Handler
+    GetRuns.Handler,
+    AddToEvaluationSet.Handler
 
 const val defaultPlatformApiUrl = "https://aigentic-backend-kib53ypjwq-ez.a.run.app/"
 
@@ -58,12 +64,17 @@ class AigenticPlatformClient(
         run: AgentRun<O>,
         agent: Agent<I, O>,
         outputSerializer: KSerializer<O>,
+        expected: Expected<O>?,
     ): RunSentResult {
-        val runDto = run.toDto(agent, outputSerializer)
+        val runDto = run.toDto(agent, outputSerializer, expected)
         val request = Gateway.Request(body = runDto)
         return when (val response = endpoints.gateway(request)) {
             is Gateway.Response201 -> {
-                RunSentResult.Success
+                RunSentResult.Success(
+                    response.body.runId
+                        .takeIf { it.isNotBlank() }
+                        ?.let(::RunId),
+                )
             }
 
             is Gateway.Response401 -> {
@@ -78,6 +89,44 @@ class AigenticPlatformClient(
                 RunSentResult.Error(
                     "${response.body.name} - ${response.body.description}",
                 )
+            }
+        }
+    }
+
+    override suspend fun <O : Any> addToEvaluationSet(
+        runId: RunId,
+        evaluationSet: String,
+        expected: O,
+        outputSerializer: KSerializer<O>,
+    ): EvaluationSubmitResult {
+        val request =
+            AddToEvaluationSet.Request(
+                runId = runId.value,
+                body =
+                    RunEvaluationDto(
+                        evaluationSet = evaluationSet,
+                        expectedResponse = Json.encodeToString(outputSerializer, expected),
+                    ),
+            )
+        return when (val response = endpoints.addToEvaluationSet(request)) {
+            is AddToEvaluationSet.Response200 -> {
+                EvaluationSubmitResult.Success
+            }
+
+            is AddToEvaluationSet.Response401 -> {
+                EvaluationSubmitResult.Unauthorized
+            }
+
+            is AddToEvaluationSet.Response404 -> {
+                EvaluationSubmitResult.NotFound
+            }
+
+            is AddToEvaluationSet.Response400 -> {
+                EvaluationSubmitResult.Error(response.body.message)
+            }
+
+            is AddToEvaluationSet.Response500 -> {
+                EvaluationSubmitResult.Error("${response.body.name} - ${response.body.description}")
             }
         }
     }
@@ -166,11 +215,23 @@ class AigenticPlatformEndpoints(
         val edge = Gateway.Handler.client(serialization)
         val rawRequest = edge.to(request)
         val rawResponse = executeRequest(rawRequest)
+        // Backward compatibility: old gateways respond 201 with an empty body (no RunCreatedDto).
+        // Surface it as a Response201 with an empty runId so the run id stays null instead of throwing.
+        if (rawResponse.statusCode == 201 && rawResponse.body?.isEmpty() != false) {
+            return Gateway.Response201(RunCreatedDto(runId = ""))
+        }
         return edge.from(rawResponse)
     }
 
     override suspend fun getRuns(request: GetRuns.Request): GetRuns.Response<*> {
         val edge = GetRuns.Handler.client(serialization)
+        val rawRequest = edge.to(request)
+        val rawResponse = executeRequest(rawRequest)
+        return edge.from(rawResponse)
+    }
+
+    override suspend fun addToEvaluationSet(request: AddToEvaluationSet.Request): AddToEvaluationSet.Response<*> {
+        val edge = AddToEvaluationSet.Handler.client(serialization)
         val rawRequest = edge.to(request)
         val rawResponse = executeRequest(rawRequest)
         return edge.from(rawResponse)

--- a/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/mapper/RequestMapper.kt
+++ b/src/platform/src/commonMain/kotlin/community/flock/aigentic/platform/mapper/RequestMapper.kt
@@ -2,6 +2,7 @@ package community.flock.aigentic.platform.mapper
 
 import community.flock.aigentic.core.agent.Agent
 import community.flock.aigentic.core.agent.AgentRun
+import community.flock.aigentic.core.agent.Expected
 import community.flock.aigentic.core.agent.state.ModelRequestInfo
 import community.flock.aigentic.core.agent.tool.Outcome
 import community.flock.aigentic.core.message.Message
@@ -34,6 +35,7 @@ import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueNumberDto
 import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueStringDto
 import community.flock.aigentic.gateway.wirespec.model.PrimitiveValueTypeDto
 import community.flock.aigentic.gateway.wirespec.model.RunDto
+import community.flock.aigentic.gateway.wirespec.model.RunEvaluationDto
 import community.flock.aigentic.gateway.wirespec.model.SenderDto
 import community.flock.aigentic.gateway.wirespec.model.StructuredOutputMessageDto
 import community.flock.aigentic.gateway.wirespec.model.StuckResultDto
@@ -65,6 +67,7 @@ private fun Parameter.toJsonSchemaString(): String =
 fun <I : Any, O : Any> AgentRun<O>.toDto(
     agent: Agent<I, O>,
     outputSerializer: KSerializer<O>,
+    expected: Expected<O>? = null,
 ): RunDto =
     RunDto(
         startedAt = startedAt.toString(),
@@ -99,6 +102,13 @@ fun <I : Any, O : Any> AgentRun<O>.toDto(
         messages = messages.mapNotNull { it.toDto() },
         modelRequests = modelRequests.map { it.toDto() },
         result = outcome.toDto(outputSerializer),
+        evaluation =
+            expected?.let {
+                RunEvaluationDto(
+                    evaluationSet = it.evaluationSet,
+                    expectedResponse = Json.encodeToString(outputSerializer, it.output),
+                )
+            },
     )
 
 private fun Parameter.toDto(): ParameterDto =

--- a/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformClientTest.kt
+++ b/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformClientTest.kt
@@ -1,10 +1,12 @@
 package community.flock.aigentic.platform.client
 
+import community.flock.aigentic.core.agent.RunId
 import community.flock.aigentic.core.platform.Authentication
 import community.flock.aigentic.core.platform.PlatformApiUrl
 import community.flock.aigentic.core.platform.RunSentResult
 import community.flock.aigentic.gateway.wirespec.endpoint.Gateway
 import community.flock.aigentic.gateway.wirespec.model.GatewayClientErrorDto
+import community.flock.aigentic.gateway.wirespec.model.RunCreatedDto
 import community.flock.aigentic.gateway.wirespec.model.ServerErrorDto
 import community.flock.aigentic.platform.util.createAgent
 import community.flock.aigentic.platform.util.createAgentRun
@@ -20,7 +22,8 @@ class AigenticPlatformClientTest :
 
         withData(
             nameFn = { "Should map ${it.wirespecResponse} to ${it.runSentResult}" },
-            TestCase(Gateway.Response201(body = Unit), RunSentResult.Success),
+            TestCase(Gateway.Response201(body = RunCreatedDto("run-123")), RunSentResult.Success(RunId("run-123"))),
+            TestCase(Gateway.Response201(body = RunCreatedDto("")), RunSentResult.Success(null)),
             TestCase(Gateway.Response401(body = Unit), RunSentResult.Unauthorized),
             TestCase(
                 Gateway.Response400(body = GatewayClientErrorDto("invalid request")),
@@ -50,7 +53,7 @@ class AigenticPlatformClientTest :
                     platformEndpoints,
                 )
 
-            val result = client.sendRun(run, agent, serializer<String>())
+            val result = client.sendRun(run, agent, serializer<String>(), null)
 
             result shouldBe it.runSentResult
         }

--- a/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformClientTest.kt
+++ b/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/AigenticPlatformClientTest.kt
@@ -23,7 +23,10 @@ class AigenticPlatformClientTest :
         withData(
             nameFn = { "Should map ${it.wirespecResponse} to ${it.runSentResult}" },
             TestCase(Gateway.Response201(body = RunCreatedDto("run-123")), RunSentResult.Success(RunId("run-123"))),
-            TestCase(Gateway.Response201(body = RunCreatedDto("")), RunSentResult.Success(null)),
+            TestCase(
+                Gateway.Response201(body = RunCreatedDto("")),
+                RunSentResult.Error("Gateway accepted the run but returned no run id"),
+            ),
             TestCase(Gateway.Response401(body = Unit), RunSentResult.Unauthorized),
             TestCase(
                 Gateway.Response400(body = GatewayClientErrorDto("invalid request")),

--- a/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/EvaluationSubmissionTest.kt
+++ b/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/EvaluationSubmissionTest.kt
@@ -1,0 +1,263 @@
+package community.flock.aigentic.platform.client
+
+import community.flock.aigentic.core.agent.Expected
+import community.flock.aigentic.core.agent.RunId
+import community.flock.aigentic.core.agent.addToEvaluationSet
+import community.flock.aigentic.core.agent.start
+import community.flock.aigentic.core.agent.tool.FINISHED_TASK_TOOL_NAME
+import community.flock.aigentic.core.annotations.AigenticParameter
+import community.flock.aigentic.core.dsl.agent
+import community.flock.aigentic.core.message.Message
+import community.flock.aigentic.core.message.ToolCall
+import community.flock.aigentic.core.message.ToolCallId
+import community.flock.aigentic.core.model.GenerationSettings
+import community.flock.aigentic.core.model.Model
+import community.flock.aigentic.core.model.ModelIdentifier
+import community.flock.aigentic.core.model.ModelResponse
+import community.flock.aigentic.core.model.Usage
+import community.flock.aigentic.core.platform.Authentication
+import community.flock.aigentic.core.platform.EvaluationSubmitResult
+import community.flock.aigentic.core.platform.Platform
+import community.flock.aigentic.core.platform.PlatformApiUrl
+import community.flock.aigentic.core.tool.Parameter
+import community.flock.aigentic.core.tool.ToolDescription
+import community.flock.aigentic.gateway.wirespec.model.RunDto
+import community.flock.aigentic.gateway.wirespec.model.RunEvaluationDto
+import community.flock.aigentic.platform.AigenticPlatform
+import community.flock.aigentic.platform.mapper.toDto
+import community.flock.aigentic.platform.util.createAgent
+import community.flock.aigentic.platform.util.createAgentRun
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.serializer
+
+@AigenticParameter
+private data class InvoiceFields(
+    val invoiceNumber: String,
+    val total: String,
+)
+
+private val lenientJson = Json { ignoreUnknownKeys = true }
+
+private val finishedInvoice = InvoiceFields("INV-001", "1250.00")
+
+private fun finishedTaskToolCall(): ToolCall =
+    ToolCall(
+        ToolCallId("1"),
+        FINISHED_TASK_TOOL_NAME,
+        Json.encodeToString(
+            JsonObject.serializer(),
+            buildJsonObject {
+                put("description", JsonPrimitive("Finished the task"))
+                put(
+                    "InvoiceFields",
+                    buildJsonObject {
+                        put("invoiceNumber", JsonPrimitive(finishedInvoice.invoiceNumber))
+                        put("total", JsonPrimitive(finishedInvoice.total))
+                    },
+                )
+            },
+        ),
+    )
+
+private val finishedInvoiceModel: Model =
+    object : Model {
+        override val modelIdentifier: ModelIdentifier =
+            object : ModelIdentifier {
+                override val stringValue = "test-model"
+            }
+        override val generationSettings = GenerationSettings.DEFAULT
+
+        override suspend fun sendRequest(
+            messages: List<Message>,
+            tools: List<ToolDescription>,
+            structuredOutputParameter: Parameter?,
+        ): ModelResponse =
+            ModelResponse(
+                message = Message.ToolCalls(listOf(finishedTaskToolCall())),
+                usage = Usage(inputTokenCount = 1, outputTokenCount = 1, thinkingOutputTokenCount = 0),
+            )
+    }
+
+private fun structuredAgent(platform: Platform) =
+    agent<Unit, InvoiceFields> {
+        platform(platform)
+        model(finishedInvoiceModel)
+        task("Extract the invoice fields") {}
+    }
+
+private fun mockPlatform(engine: MockEngine): Platform {
+    val auth = Authentication.BasicAuth("user", "pass")
+    val url = PlatformApiUrl("")
+    return AigenticPlatform(
+        authentication = auth,
+        apiUrl = url,
+        client =
+            AigenticPlatformClient(
+                basicAuth = auth,
+                apiUrl = url,
+                endpoints = AigenticPlatformEndpoints(auth, url, engine),
+            ),
+    )
+}
+
+private suspend fun HttpRequestData.bodyText(): String = body.toByteArray().decodeToString()
+
+class EvaluationSubmissionTest :
+    DescribeSpec({
+
+        describe("RequestMapper evaluation field") {
+
+            it("builds RunEvaluationDto with evaluationSet and serialized output when expected is present") {
+                val agent = createAgent()
+                val run = createAgentRun()
+
+                val dto =
+                    run.toDto(
+                        agent,
+                        serializer<String>(),
+                        Expected(evaluationSet = "golden-set", output = "the-expected-output"),
+                    )
+
+                val evaluation = dto.evaluation.shouldNotBeNull()
+                evaluation.evaluationSet shouldBe "golden-set"
+                evaluation.expectedResponse shouldBe Json.encodeToString(serializer<String>(), "the-expected-output")
+            }
+
+            it("leaves evaluation null when expected is absent") {
+                val agent = createAgent()
+                val run = createAgentRun()
+
+                val dto = run.toDto(agent, serializer<String>(), null)
+
+                dto.evaluation shouldBe null
+            }
+        }
+
+        describe("start with expected") {
+
+            it("puts the serialized expected output and evaluationSet in the POST body") {
+                var capturedBody: String? = null
+                val engine =
+                    MockEngine { request ->
+                        when (request.method to request.url.encodedPath) {
+                            (HttpMethod.Post to "/gateway/runs") -> {
+                                capturedBody = request.bodyText()
+                                respond(
+                                    content = ByteReadChannel("""{"runId":"run-1"}"""),
+                                    status = HttpStatusCode.Created,
+                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                                )
+                            }
+
+                            else -> {
+                                error("Unexpected endpoint called! ${request.url.encodedPath}")
+                            }
+                        }
+                    }
+
+                val agent = structuredAgent(mockPlatform(engine))
+
+                agent.start(
+                    expected = Expected(evaluationSet = "invoice-golden-set", output = finishedInvoice),
+                )
+
+                val body = capturedBody.shouldNotBeNull()
+                val runDto = lenientJson.decodeFromString(RunDto.serializer(), body)
+                val evaluation = runDto.evaluation.shouldNotBeNull()
+                evaluation.evaluationSet shouldBe "invoice-golden-set"
+                evaluation.expectedResponse shouldBe Json.encodeToString(serializer<InvoiceFields>(), finishedInvoice)
+            }
+
+            it("populates run.platformRunId from the 201 RunCreatedDto body") {
+                val engine =
+                    MockEngine { request ->
+                        when (request.method to request.url.encodedPath) {
+                            (HttpMethod.Post to "/gateway/runs") -> {
+                                respond(
+                                    content = ByteReadChannel("""{"runId":"run-42"}"""),
+                                    status = HttpStatusCode.Created,
+                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                                )
+                            }
+
+                            else -> {
+                                error("Unexpected endpoint called! ${request.url.encodedPath}")
+                            }
+                        }
+                    }
+
+                val agent = structuredAgent(mockPlatform(engine))
+
+                val run = agent.start()
+
+                run.platformRunId shouldBe RunId("run-42")
+            }
+
+            it("leaves run.platformRunId null when the 201 body is empty (old gateways)") {
+                val engine =
+                    MockEngine { request ->
+                        when (request.method to request.url.encodedPath) {
+                            (HttpMethod.Post to "/gateway/runs") -> {
+                                respond(content = ByteReadChannel.Empty, status = HttpStatusCode.Created)
+                            }
+
+                            else -> {
+                                error("Unexpected endpoint called! ${request.url.encodedPath}")
+                            }
+                        }
+                    }
+
+                val agent = structuredAgent(mockPlatform(engine))
+
+                val run = agent.start()
+
+                run.platformRunId shouldBe null
+            }
+        }
+
+        describe("addToEvaluationSet") {
+
+            it("POSTs the serialized expected output to /gateway/runs/{runId}/evaluation") {
+                var capturedPath: String? = null
+                var capturedBody: String? = null
+                val engine =
+                    MockEngine { request ->
+                        capturedPath = request.url.encodedPath
+                        capturedBody = request.bodyText()
+                        respond(content = ByteReadChannel.Empty, status = HttpStatusCode.OK)
+                    }
+
+                val agent = structuredAgent(mockPlatform(engine))
+
+                val result =
+                    agent.addToEvaluationSet(
+                        runId = RunId("run-99"),
+                        evaluationSet = "golden",
+                        expected = InvoiceFields("INV-009", "9.99"),
+                    )
+
+                result shouldBe EvaluationSubmitResult.Success
+                capturedPath shouldBe "/gateway/runs/run-99/evaluation"
+                val body = capturedBody.shouldNotBeNull()
+                val evaluationDto = lenientJson.decodeFromString(RunEvaluationDto.serializer(), body)
+                evaluationDto.evaluationSet shouldBe "golden"
+                evaluationDto.expectedResponse shouldBe
+                    Json.encodeToString(serializer<InvoiceFields>(), InvoiceFields("INV-009", "9.99"))
+            }
+        }
+    })

--- a/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/EvaluationSubmissionTest.kt
+++ b/src/platform/src/jvmTest/kotlin/community/flock/aigentic/platform/client/EvaluationSubmissionTest.kt
@@ -232,7 +232,7 @@ class EvaluationSubmissionTest :
 
         describe("addToEvaluationSet") {
 
-            it("POSTs the serialized expected output to /gateway/runs/{runId}/evaluation") {
+            it("POSTs the serialized expected output to /gateway/runs/{runId}/annotations") {
                 var capturedPath: String? = null
                 var capturedBody: String? = null
                 val engine =
@@ -246,13 +246,13 @@ class EvaluationSubmissionTest :
 
                 val result =
                     agent.addToEvaluationSet(
-                        runId = RunId("run-99"),
+                        runId = "run-99",
                         evaluationSet = "golden",
                         expected = InvoiceFields("INV-009", "9.99"),
                     )
 
                 result shouldBe EvaluationSubmitResult.Success
-                capturedPath shouldBe "/gateway/runs/run-99/evaluation"
+                capturedPath shouldBe "/gateway/runs/run-99/annotations"
                 val body = capturedBody.shouldNotBeNull()
                 val evaluationDto = lenientJson.decodeFromString(RunEvaluationDto.serializer(), body)
                 evaluationDto.evaluationSet shouldBe "golden"

--- a/src/platform/wirespec/gateway.ws
+++ b/src/platform/wirespec/gateway.ws
@@ -247,7 +247,7 @@ endpoint GetRuns GET /gateway/runs ? { tags: String? } -> {
     500 -> ServerErrorDto
 }
 
-endpoint AddToEvaluationSet POST RunEvaluationDto /gateway/runs/{runId: String}/evaluation -> {
+endpoint AddRunAnnotations POST RunEvaluationDto /gateway/runs/{runId: String}/annotations -> {
     200 -> Unit
     400 -> GatewayClientErrorDto
     401 -> Unit

--- a/src/platform/wirespec/gateway.ws
+++ b/src/platform/wirespec/gateway.ws
@@ -4,7 +4,8 @@ type RunDto {
     config: ConfigDto,
     result: ResultDto,
     messages: MessageDto[],
-    modelRequests: ModelRequestInfoDto[]
+    modelRequests: ModelRequestInfoDto[],
+    evaluation: RunEvaluationDto?
 }
 
 type ModelRequestInfoDto {
@@ -213,8 +214,17 @@ type ServerErrorDto {
     description: String
 }
 
+type RunEvaluationDto {
+    evaluationSet: String,
+    expectedResponse: String
+}
+
+type RunCreatedDto {
+    runId: String
+}
+
 endpoint Gateway POST RunDto /gateway/runs -> {
-    201 -> Unit
+    201 -> RunCreatedDto
     401 -> Unit
     400 -> GatewayClientErrorDto
     500 -> ServerErrorDto
@@ -234,5 +244,13 @@ endpoint GetRuns GET /gateway/runs ? { tags: String? } -> {
     200 -> RunDetailsDto[]
     404 -> Unit
     401 -> Unit
+    500 -> ServerErrorDto
+}
+
+endpoint AddToEvaluationSet POST RunEvaluationDto /gateway/runs/{runId: String}/evaluation -> {
+    200 -> Unit
+    400 -> GatewayClientErrorDto
+    401 -> Unit
+    404 -> Unit
     500 -> ServerErrorDto
 }


### PR DESCRIPTION
## Why

During an agent's development phase the developer often **already has the expected values** (e.g. a folder of PDFs plus the expected extracted fields). Today the only way to seed annotations on the Aigentic Platform is to publish runs and then manually annotate each one field-by-field in the UI. This lets the developer attach the **expected structured output** directly in the agent DSL, so a published run is automatically added to a named evaluation set and scored — no manual annotation step.

**Scope v1: structured-output agents only.** The wire contract is designed so tool-call expectations can be added later, but tool calls are not implemented now.

> Pairs with the companion server-side PR in `flock-community/aigentic-platform` (same branch). The new `evaluation` field is optional, so the server is deployable independently — old clients omit it, old gateways ignore it.

## Two entry points

**Upfront** — expected value known at `start()`:
```kotlin
extractor.start(
    Attachment.Base64.pdf(pdf1Base64),
    expected = Expected(
        evaluationSet = "invoice-golden-set",
        output = InvoiceFields("INV-001", "D-100", "1250.00"),
    ),
)
```

**Deferred / human-in-the-loop** — only a `runId` known later (e.g. after your own backend confirms/corrects the value):
```kotlin
val run = extractor.start(Attachment.Base64.pdf(pdf1Base64))
val runId = run.platformRunId ?: error("run was not published")
val confirmed: InvoiceFields = myBackend.review(run.outcome)
extractor.addToEvaluationSet(runId, "invoice-golden-set", expected = confirmed)
```

Both compile to one uniform wire shape `(evaluationSet, expectedResponse-JSON)`; the platform turns it into evaluation fields + annotations.

## What changed

**Contract** (`src/platform/wirespec/gateway.ws`, kept identical to the platform repo):
- `type RunEvaluationDto { evaluationSet, expectedResponse }` and `type RunCreatedDto { runId }`
- optional `evaluation: RunEvaluationDto?` on `RunDto`
- `POST /gateway/runs` `201` now returns `RunCreatedDto` (was `Unit`) so the client learns the run id
- new `POST /gateway/runs/{runId}/evaluation` (`AddToEvaluationSet`) reusing `RunEvaluationDto`

**Client**:
- new `Expected<O>(evaluationSet, output)` wrapper in core (the `platform { }` block and `Platform` interface are unchanged)
- `start(..., expected: Expected<O>? = null)` — trailing name-bound param; serialized with the same `outputSerializer` that already encodes `FinishedResultDto.response`, so the expected JSON lines up with the run's own response server-side
- `AgentRun.platformRunId: RunId?` populated from the `201 RunCreatedDto` (null-safe for old gateways that send an empty 201 body)
- deferred `Agent.addToEvaluationSet(runId, evaluationSet, expected)` + `Platform.addToEvaluationSet(...)` + sealed `EvaluationSubmitResult`

## Testing

`./gradlew --no-build-cache clean :src:core:jvmTest :src:platform:jvmTest` — **green**; `spotlessCheck` clean. New tests cover: mapper builds/omits `RunEvaluationDto`; `start(expected = …)` puts the serialized output + set name in the POST body; `start()` populates `platformRunId` (and stays null on an empty 201 body); `addToEvaluationSet(...)` POSTs to the `/evaluation` path.

https://claude.ai/code/session_01DRjhdMQLdNYJ6SY5ML1LUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRjhdMQLdNYJ6SY5ML1LUb)_