### PR TITLE
chore: release version 0.10.0

### DIFF
--- a/src/plugins/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/src/plugins/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "community.flock.aigentic"
-    version = "0.10.0-SNAPSHOT"
+    version = "0.10.0"
 }
 
 nexusPublishing {


### PR DESCRIPTION
## Summary
- Sets the project version to `0.10.0` (removing the `-SNAPSHOT` suffix) in `root.publication.gradle.kts`.
- Merging this into `main` triggers the `Deploy to central` workflow, which will:
  - Publish `0.10.0` to Maven Central
  - Create a GitHub release `v0.10.0`
  - Automatically bump the version to `0.11.0-SNAPSHOT` and open a follow-up PR with that change

## Test plan
- [x] CI build passes on this PR
- [ ] After merge, verify the `Deploy to central` workflow publishes `0.10.0` and creates the GitHub release
- [ ] Verify the automated version-bump PR to `0.11.0-SNAPSHOT` is opened


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcBq1PNGsUBSbhA8WUuFF4)_