### PR TITLE
fix: unwrap Optional blockReason in VertexAI response mapper

### DIFF
--- a/src/providers/vertexai/src/jvmMain/kotlin/community/flock/aigentic/vertexai/response/ResponseMapper.kt
+++ b/src/providers/vertexai/src/jvmMain/kotlin/community/flock/aigentic/vertexai/response/ResponseMapper.kt
@@ -15,7 +15,7 @@ import generateRandomString
 import kotlin.jvm.optionals.getOrNull
 
 fun GenerateContentResponse.toModelResponse(isStructuredOutput: Boolean): ModelResponse {
-    promptFeedback().getOrNull()?.blockReason()?.let {
+    promptFeedback().getOrNull()?.blockReason()?.getOrNull()?.let {
         aigenticException("VertexAI blocked the prompt because of reason: '$it'")
     }
 


### PR DESCRIPTION
## Problem

Running a VertexAI agent with certain models (e.g. `gemini-3.5-flash`) fails with:

```
VertexAI blocked the prompt because of reason: 'Optional.empty'
```

even though the prompt was never actually blocked. Other models (e.g. `gemini-3.1-flash-lite`) work fine.

## Root cause

In `ResponseMapper.toModelResponse`, the block-reason check used the Google `genai` Java SDK, whose accessors return `java.util.Optional` rather than nullables:

```kotlin
promptFeedback().getOrNull()?.blockReason()?.let {
    aigenticException("VertexAI blocked the prompt because of reason: '$it'")
}
```

`promptFeedback()` was correctly unwrapped with `.getOrNull()`, but `blockReason()` was not. Since `blockReason()` returns a non-null `Optional<BlockedReason>`, the `?.let { ... }` fired whenever a `promptFeedback` object was present — regardless of whether a block reason actually existed — and `$it` interpolated the raw `Optional`, which stringifies to `Optional.empty`.

This explains the model dependency: `gemini-3.1-flash-lite` returns no `promptFeedback` (so the check is skipped), while `gemini-3.5-flash` returns a `promptFeedback` object with an empty `blockReason`, tripping the missing unwrap and throwing a bogus exception.

## Fix

Add the missing `.getOrNull()` on `blockReason()` so the exception only fires when a real block reason is present:

```kotlin
promptFeedback().getOrNull()?.blockReason()?.getOrNull()?.let {
    aigenticException("VertexAI blocked the prompt because of reason: '$it'")
}
```

## Verification

- `:src:providers:vertexai:compileKotlinJvm` compiles cleanly.
- `spotlessApply` reports no formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hcs4tsgqxoN7L29oYmpeg2)_